### PR TITLE
Added scrolling with mouse wheel

### DIFF
--- a/SonLVL/ScrollingPanel.Designer.cs
+++ b/SonLVL/ScrollingPanel.Designer.cs
@@ -72,6 +72,7 @@
 			this.panel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.panel_MouseDown);
 			this.panel.MouseMove += new System.Windows.Forms.MouseEventHandler(this.panel_MouseMove);
 			this.panel.MouseUp += new System.Windows.Forms.MouseEventHandler(this.panel_MouseUp);
+			this.panel.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.panel_MouseWheel);
 			this.panel.Resize += new System.EventHandler(this.panel_Resize);
 			// 
 			// vScrollBar

--- a/SonLVL/ScrollingPanel.cs
+++ b/SonLVL/ScrollingPanel.cs
@@ -146,6 +146,31 @@ namespace SonicRetro.SonLVL
 			PanelMouseMove(sender, e);
 		}
 
+		private void panel_MouseWheel(object sender, MouseEventArgs e)
+		{
+			bool shiftHeld = 0 != (ModifierKeys & Keys.Shift);
+			bool ctrlHeld = 0 != (ModifierKeys & Keys.Control);
+
+			int smallChange = shiftHeld ? VScrollSmallChange : HScrollSmallChange;
+			int largeChange = shiftHeld ? VScrollLargeChange : HScrollLargeChange;
+
+			int delta;
+			if (ctrlHeld) {
+				delta = largeChange * e.Delta / -120;
+			}
+			else {
+				int lines = SystemInformation.MouseWheelScrollLines < 1 ? 3 : SystemInformation.MouseWheelScrollLines;
+				delta = smallChange * lines * e.Delta / -120;
+			}
+
+			if(shiftHeld && VScrollEnabled) {
+				VScrollValue = (int)Math.Min(Math.Max(VScrollValue + delta, VScrollMinimum), VScrollMaximum);
+			}
+			else if(!shiftHeld && HScrollEnabled) {
+				HScrollValue = (int)Math.Min(Math.Max(HScrollValue + delta, HScrollMinimum), HScrollMaximum);
+			}
+		}
+
 		private void panel_DragEnter(object sender, DragEventArgs e)
 		{
 			PanelDragEnter(sender, e);


### PR DESCRIPTION
I decided to make horizontal scroll the default, because levels are
usually more wider than higher.

Holding Shift makes it scroll vertically. Holding Ctrl increases the
scroll step.

Note that the scroll step without Ctrl held is dependend on system
settings.

fixes #5