### PR TITLE
Initial support for custom engines in SonLVL

### DIFF
--- a/SonLVL/MainForm.cs
+++ b/SonLVL/MainForm.cs
@@ -2083,18 +2083,30 @@ namespace SonicRetro.SonLVL.GUI
 			{
 				case Keys.Up:
 					if (!loaded) return;
+					if(e.Alt && SelectedItems.Count > 0) {
+						foreach(Entry e in SelectedItems) e.Y--; }
+						else
 					objectPanel.VScrollValue = (int)Math.Max(objectPanel.VScrollValue - vstep, objectPanel.VScrollMinimum);
 					break;
 				case Keys.Down:
 					if (!loaded) return;
+					if(e.Alt && SelectedItems.Count > 0) {
+						foreach(Entry e in SelectedItems) e.Y++; }
+						else
 					objectPanel.VScrollValue = (int)Math.Min(objectPanel.VScrollValue + vstep, objectPanel.VScrollMaximum - LevelData.Level.ChunkHeight + 1);
 					break;
 				case Keys.Left:
 					if (!loaded) return;
+					if(e.Alt && SelectedItems.Count > 0) {
+						foreach(Entry e in SelectedItems) e.X--; }
+						else
 					objectPanel.HScrollValue = (int)Math.Max(objectPanel.HScrollValue - hstep, objectPanel.HScrollMinimum);
 					break;
 				case Keys.Right:
 					if (!loaded) return;
+					if(e.Alt && SelectedItems.Count > 0) {
+						foreach(Entry e in SelectedItems) e.X++; }
+						else
 					objectPanel.HScrollValue = (int)Math.Min(objectPanel.HScrollValue + hstep, objectPanel.HScrollMaximum - LevelData.Level.ChunkWidth + 1);
 					break;
 				case Keys.Delete:

--- a/SonLVL/MainForm.cs
+++ b/SonLVL/MainForm.cs
@@ -2079,35 +2079,70 @@ namespace SonicRetro.SonLVL.GUI
 		{
 			long hstep = e.Control ? int.MaxValue : e.Shift ? LevelData.Level.ChunkWidth : 16;
 			long vstep = e.Control ? int.MaxValue : e.Shift ? LevelData.Level.ChunkHeight : 16;
+
+			ushort objstep = (ushort)(e.Shift ? 16 : 1);
+
 			switch (e.KeyCode)
 			{
 				case Keys.Up:
 					if (!loaded) return;
-					if(e.Alt && SelectedItems.Count > 0) {
-						foreach(Entry e in SelectedItems) e.Y--; }
-						else
-					objectPanel.VScrollValue = (int)Math.Max(objectPanel.VScrollValue - vstep, objectPanel.VScrollMinimum);
+					if(SelectedItems.Count > 0) 
+					{
+						foreach(Entry en in SelectedItems) 
+						{
+							en.Y -= objstep;
+							en.UpdateSprite();
+						}
+						SelectedObjectChanged();
+						DrawLevel();
+					}
+					else
+						objectPanel.VScrollValue = (int)Math.Max(objectPanel.VScrollValue - vstep, objectPanel.VScrollMinimum);
 					break;
 				case Keys.Down:
 					if (!loaded) return;
-					if(e.Alt && SelectedItems.Count > 0) {
-						foreach(Entry e in SelectedItems) e.Y++; }
-						else
-					objectPanel.VScrollValue = (int)Math.Min(objectPanel.VScrollValue + vstep, objectPanel.VScrollMaximum - LevelData.Level.ChunkHeight + 1);
+					if(SelectedItems.Count > 0) 
+					{
+						foreach(Entry en in SelectedItems) 
+						{
+							en.Y += objstep;
+							en.UpdateSprite();
+						}
+						SelectedObjectChanged();
+						DrawLevel();
+					}
+					else
+						objectPanel.VScrollValue = (int)Math.Min(objectPanel.VScrollValue + vstep, objectPanel.VScrollMaximum - LevelData.Level.ChunkHeight + 1);
 					break;
 				case Keys.Left:
 					if (!loaded) return;
-					if(e.Alt && SelectedItems.Count > 0) {
-						foreach(Entry e in SelectedItems) e.X--; }
-						else
-					objectPanel.HScrollValue = (int)Math.Max(objectPanel.HScrollValue - hstep, objectPanel.HScrollMinimum);
+					if(SelectedItems.Count > 0) 
+					{
+						foreach(Entry en in SelectedItems) 
+						{
+							en.X -= objstep;
+							en.UpdateSprite();
+						}
+						SelectedObjectChanged();
+						DrawLevel();
+					}
+					else
+						objectPanel.HScrollValue = (int)Math.Max(objectPanel.HScrollValue - hstep, objectPanel.HScrollMinimum);
 					break;
 				case Keys.Right:
 					if (!loaded) return;
-					if(e.Alt && SelectedItems.Count > 0) {
-						foreach(Entry e in SelectedItems) e.X++; }
-						else
-					objectPanel.HScrollValue = (int)Math.Min(objectPanel.HScrollValue + hstep, objectPanel.HScrollMaximum - LevelData.Level.ChunkWidth + 1);
+					if(SelectedItems.Count > 0) 
+					{
+						foreach(Entry en in SelectedItems) 
+						{
+							en.X += objstep;
+							en.UpdateSprite();
+						}
+						SelectedObjectChanged();
+						DrawLevel();
+					}
+					else
+						objectPanel.HScrollValue = (int)Math.Min(objectPanel.HScrollValue + hstep, objectPanel.HScrollMaximum - LevelData.Level.ChunkWidth + 1);
 					break;
 				case Keys.Delete:
 					if (!loaded) return;

--- a/SonLVL/MainForm.cs
+++ b/SonLVL/MainForm.cs
@@ -416,7 +416,11 @@ namespace SonicRetro.SonLVL.GUI
 				}
 			}
 			timeZoneToolStripMenuItem.Visible = false;
-			switch (LevelData.Game.EngineVersion)
+			if(LevelData.Game.SonLVLIconPath != null)
+			{
+				Icon = new Icon(LevelData.Game.SonLVLIconPath);
+			}
+			else switch (LevelData.Game.EngineVersion)
 			{
 				case EngineVersion.S1:
 					Icon = Properties.Resources.gogglemon;
@@ -439,7 +443,7 @@ namespace SonicRetro.SonLVL.GUI
 				default:
 					throw new NotImplementedException("Game type " + LevelData.Game.EngineVersion.ToString() + " is not supported!");
 			}
-			Text = "SonLVL - " + LevelData.Game.EngineVersion.ToString();
+			Text = "SonLVL - " + LevelData.Game.GameName;
 			buildAndRunToolStripMenuItem.Enabled = LevelData.Game.BuildScript != null & (LevelData.Game.ROMFile != null | LevelData.Game.RunCommand != null);
 			if (Settings.MRUList.Count == 0)
 				recentProjectsToolStripMenuItem.DropDownItems.Remove(noneToolStripMenuItem2);
@@ -499,7 +503,7 @@ namespace SonicRetro.SonLVL.GUI
 			((ToolStripMenuItem)sender).Checked = true;
 			Enabled = false;
 			UseWaitCursor = true;
-			Text = "SonLVL - " + LevelData.Game.EngineVersion + " - Loading " + LevelData.Game.GetLevelInfo((string)((ToolStripMenuItem)sender).Tag).DisplayName + "...";
+			Text = "SonLVL - " + LevelData.Game.GameName + " - Loading " + LevelData.Game.GetLevelInfo((string)((ToolStripMenuItem)sender).Tag).DisplayName + "...";
 			LevelData.littleendian = false;
 			string anipath = Path.Combine(Application.StartupPath, "loadanim");
 			Dictionary<string, AnimationInfo> animini = AnimationInfo.Load(Path.Combine(anipath, "anims.ini"));
@@ -614,7 +618,7 @@ namespace SonicRetro.SonLVL.GUI
 				}
 				using (LoadErrorDialog ed = new LoadErrorDialog(true, msg))
 					ed.ShowDialog(this);
-				Text = "SonLVL - " + LevelData.Game.EngineVersion.ToString();
+				Text = "SonLVL - " + LevelData.Game.GameName;
 				Enabled = true;
 				loadingAnimation1.Hide();
 				return;
@@ -696,7 +700,7 @@ namespace SonicRetro.SonLVL.GUI
 			ObjectSelect.listView2.Items.Clear();
 			ObjectSelect.imageList2.Images.Clear();
 			ColIndBox.Visible = collisionToolStripMenuItem.Visible = LevelData.ColInds1.Count > 0;
-			Text = "SonLVL - " + LevelData.Game.EngineVersion + " - " + LevelData.Level.DisplayName;
+			Text = "SonLVL - " + LevelData.Game.GameName + " - " + LevelData.Level.DisplayName;
 			UpdateScrollBars();
 			objectPanel.HScrollValue = 0;
 			objectPanel.HScrollSmallChange = 16;

--- a/SonLVL/MainForm.cs
+++ b/SonLVL/MainForm.cs
@@ -179,34 +179,34 @@ namespace SonicRetro.SonLVL.GUI
 				try
 				{
 #endif
-					using (System.Net.WebClient cli = new System.Net.WebClient())
-					{
-						string updatefile = Path.GetTempFileName();
-						cli.DownloadFile("http://mm.reimuhakurei.net/SonLVL/update.ini", updatefile);
-						updini = IniSerializer.Deserialize<Dictionary<string, UpdateInfo>>(updatefile);
-						File.Delete(updatefile);
-					}
-					List<string> updates = new List<string>();
-					foreach (KeyValuePair<string, UpdateInfo> item in updini)
-					{
-						if (downloaded.ContainsKey(item.Key))
-							if (downloaded[item.Key] < item.Value.Revision)
-								updates.Add(item.Key);
-					}
-					if (updates.Count > 0)
-					{
+				using (System.Net.WebClient cli = new System.Net.WebClient())
+				{
+					string updatefile = Path.GetTempFileName();
+					cli.DownloadFile("http://mm.reimuhakurei.net/SonLVL/update.ini", updatefile);
+					updini = IniSerializer.Deserialize<Dictionary<string, UpdateInfo>>(updatefile);
+					File.Delete(updatefile);
+				}
+				List<string> updates = new List<string>();
+				foreach (KeyValuePair<string, UpdateInfo> item in updini)
+				{
+					if (downloaded.ContainsKey(item.Key))
+						if (downloaded[item.Key] < item.Value.Revision)
+							updates.Add(item.Key);
+				}
+				if (updates.Count > 0)
+				{
 					List<string> message = new List<string> { "The following components have updates available:" };
 					foreach (string item in updates)
-							message.Add('\t' + item);
-						message.Add(string.Empty);
-						message.Add("Do you want to run the updater?");
-						if (MessageBox.Show(this, string.Join(Environment.NewLine, message.ToArray()), "SonLVL Updates", MessageBoxButtons.YesNo, MessageBoxIcon.Information) == DialogResult.Yes)
-						{
-							System.Diagnostics.Process.Start("SonLVL Updater.exe");
-							Close();
-							return;
-						}
+						message.Add('\t' + item);
+					message.Add(string.Empty);
+					message.Add("Do you want to run the updater?");
+					if (MessageBox.Show(this, string.Join(Environment.NewLine, message.ToArray()), "SonLVL Updates", MessageBoxButtons.YesNo, MessageBoxIcon.Information) == DialogResult.Yes)
+					{
+						System.Diagnostics.Process.Start("SonLVL Updater.exe");
+						Close();
+						return;
 					}
+				}
 #if !DEBUG
 				}
 				catch (Exception ex)
@@ -416,33 +416,36 @@ namespace SonicRetro.SonLVL.GUI
 				}
 			}
 			timeZoneToolStripMenuItem.Visible = false;
-			if(LevelData.Game.SonLVLIconPath != null)
+			if (LevelData.Game.SonLVLIconPath != null)
 			{
 				Icon = new Icon(LevelData.Game.SonLVLIconPath);
 			}
 			else switch (LevelData.Game.EngineVersion)
-			{
-				case EngineVersion.S1:
-					Icon = Properties.Resources.gogglemon;
-					break;
-				case EngineVersion.SCD:
-				case EngineVersion.SCDPC:
-					Icon = Properties.Resources.clockmon;
-					timeZoneToolStripMenuItem.Visible = true;
-					break;
-				case EngineVersion.S2:
-				case EngineVersion.S2NA:
-					Icon = Properties.Resources.Tailsmon2;
-					break;
-				case EngineVersion.S3K:
-					Icon = Properties.Resources.watermon;
-					break;
-				case EngineVersion.SKC:
-					Icon = Properties.Resources.lightningmon;
-					break;
-				default:
-					throw new NotImplementedException("Game type " + LevelData.Game.EngineVersion.ToString() + " is not supported!");
-			}
+				{
+					case EngineVersion.S1:
+						Icon = Properties.Resources.gogglemon;
+						break;
+					case EngineVersion.SCD:
+					case EngineVersion.SCDPC:
+						Icon = Properties.Resources.clockmon;
+						timeZoneToolStripMenuItem.Visible = true;
+						break;
+					case EngineVersion.S2:
+					case EngineVersion.S2NA:
+						Icon = Properties.Resources.Tailsmon2;
+						break;
+					case EngineVersion.S3K:
+						Icon = Properties.Resources.watermon;
+						break;
+					case EngineVersion.SKC:
+						Icon = Properties.Resources.lightningmon;
+						break;
+					case EngineVersion.Custom:		// user should specify icon in "sonlvlicon" in INI file...
+						Icon = Properties.Resources.ringmon1;
+						break;
+					default:
+						throw new NotImplementedException("Game type " + LevelData.Game.EngineVersion.ToString() + " is not supported!");
+				}
 			Text = "SonLVL - " + LevelData.Game.GameName;
 			buildAndRunToolStripMenuItem.Enabled = LevelData.Game.BuildScript != null & (LevelData.Game.ROMFile != null | LevelData.Game.RunCommand != null);
 			if (Settings.MRUList.Count == 0)
@@ -566,37 +569,37 @@ namespace SonicRetro.SonLVL.GUI
 			try
 			{
 #endif
-				SelectedChunk = 0;
-				UndoList = new Stack<UndoAction>();
-				RedoList = new Stack<UndoAction>();
-				LevelData.LoadLevel((string)e.Argument, true);
-				if (LevelData.Level.TwoPlayerCompatible && LevelData.Tiles.Count % 2 == 1)
-				{
-					LevelData.Tiles.Add(new byte[32]);
-					LevelData.UpdateTileArray();
-				}
-				LevelImgPalette = new Bitmap(1, 1, PixelFormat.Format8bppIndexed).Palette;
-				LevelData.BmpPal.Entries.CopyTo(LevelImgPalette.Entries, 0);
-				LevelImgPalette.Entries[LevelData.ColorTransparent] = LevelData.PaletteToColor(2, 0, false);
-				LevelImgPalette.Entries[LevelData.ColorWhite] = Color.White;
-				LevelImgPalette.Entries[LevelData.ColorYellow] = Color.Yellow;
-				LevelImgPalette.Entries[LevelData.ColorBlack] = Color.Black;
-				LevelImgPalette.Entries[ColorGrid] = Settings.GridColor;
-				curpal = new Color[16];
-				switch (LevelData.Level.ChunkFormat)
-				{
-					case EngineVersion.S1:
-					case EngineVersion.SCD:
-					case EngineVersion.SCDPC:
-						copiedChunkBlock = new S1ChunkBlock();
-						break;
-					case EngineVersion.S2NA:
-					case EngineVersion.S2:
-					case EngineVersion.S3K:
-					case EngineVersion.SKC:
-						copiedChunkBlock = new S2ChunkBlock();
-						break;
-				}
+			SelectedChunk = 0;
+			UndoList = new Stack<UndoAction>();
+			RedoList = new Stack<UndoAction>();
+			LevelData.LoadLevel((string)e.Argument, true);
+			if (LevelData.Level.TwoPlayerCompatible && LevelData.Tiles.Count % 2 == 1)
+			{
+				LevelData.Tiles.Add(new byte[32]);
+				LevelData.UpdateTileArray();
+			}
+			LevelImgPalette = new Bitmap(1, 1, PixelFormat.Format8bppIndexed).Palette;
+			LevelData.BmpPal.Entries.CopyTo(LevelImgPalette.Entries, 0);
+			LevelImgPalette.Entries[LevelData.ColorTransparent] = LevelData.PaletteToColor(2, 0, false);
+			LevelImgPalette.Entries[LevelData.ColorWhite] = Color.White;
+			LevelImgPalette.Entries[LevelData.ColorYellow] = Color.Yellow;
+			LevelImgPalette.Entries[LevelData.ColorBlack] = Color.Black;
+			LevelImgPalette.Entries[ColorGrid] = Settings.GridColor;
+			curpal = new Color[16];
+			switch (LevelData.Level.ChunkFormat)
+			{
+				case EngineVersion.S1:
+				case EngineVersion.SCD:
+				case EngineVersion.SCDPC:
+					copiedChunkBlock = new S1ChunkBlock();
+					break;
+				case EngineVersion.S2NA:
+				case EngineVersion.S2:
+				case EngineVersion.S3K:
+				case EngineVersion.SKC:
+					copiedChunkBlock = new S2ChunkBlock();
+					break;
+			}
 #if !DEBUG
 			}
 			catch (Exception ex) { initerror = ex; }
@@ -1462,11 +1465,11 @@ namespace SonicRetro.SonLVL.GUI
 		private void foregroundToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			using (SaveFileDialog a = new SaveFileDialog()
-						{
-							DefaultExt = "png",
-							Filter = "PNG Files|*.png",
-							RestoreDirectory = true
-						})
+			{
+				DefaultExt = "png",
+				Filter = "PNG Files|*.png",
+				RestoreDirectory = true
+			})
 				if (a.ShowDialog() == DialogResult.OK)
 				{
 					if (exportArtcollisionpriorityToolStripMenuItem.Checked)
@@ -1565,11 +1568,11 @@ namespace SonicRetro.SonLVL.GUI
 		private void backgroundToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			using (SaveFileDialog a = new SaveFileDialog()
-						{
-							DefaultExt = "png",
-							Filter = "PNG Files|*.png",
-							RestoreDirectory = true
-						})
+			{
+				DefaultExt = "png",
+				Filter = "PNG Files|*.png",
+				RestoreDirectory = true
+			})
 				if (a.ShowDialog() == DialogResult.OK)
 				{
 					if (exportArtcollisionpriorityToolStripMenuItem.Checked)
@@ -1912,7 +1915,7 @@ namespace SonicRetro.SonLVL.GUI
 						Math.Max(selpoint.X, lastmouse.X) - camera.X,
 						Math.Max(selpoint.Y, lastmouse.Y) - camera.Y);
 						LevelGfx.FillRectangle(selectionBrush, selbnds);
-						selbnds.Width--;	selbnds.Height--;
+						selbnds.Width--; selbnds.Height--;
 						LevelGfx.DrawRectangle(selectionPen, selbnds);
 					}
 					break;
@@ -2818,17 +2821,17 @@ namespace SonicRetro.SonLVL.GUI
 			switch (e.Button)
 			{
 				case MouseButtons.Left:
-						byte c = LevelData.Layout.FGLayout[chunkpoint.X, chunkpoint.Y];
-						if (c != SelectedChunk)
-						{
-							locs.Add(chunkpoint);
-							tiles.Add(c);
-							LevelData.Layout.FGLayout[chunkpoint.X, chunkpoint.Y] = (byte)SelectedChunk;
-							if (LevelData.LayoutFormat.HasLoopFlag)
-								LevelData.Layout.FGLoop[chunkpoint.X, chunkpoint.Y] = LevelData.Level.LoopChunks.Contains((byte)SelectedChunk);
-							DoLayoutCopy();
-							DrawLevel();
-						}
+					byte c = LevelData.Layout.FGLayout[chunkpoint.X, chunkpoint.Y];
+					if (c != SelectedChunk)
+					{
+						locs.Add(chunkpoint);
+						tiles.Add(c);
+						LevelData.Layout.FGLayout[chunkpoint.X, chunkpoint.Y] = (byte)SelectedChunk;
+						if (LevelData.LayoutFormat.HasLoopFlag)
+							LevelData.Layout.FGLoop[chunkpoint.X, chunkpoint.Y] = LevelData.Level.LoopChunks.Contains((byte)SelectedChunk);
+						DoLayoutCopy();
+						DrawLevel();
+					}
 					break;
 				case MouseButtons.Right:
 					if (!selecting)
@@ -3923,7 +3926,7 @@ namespace SonicRetro.SonLVL.GUI
 					return;
 			}
 			if (LevelData.Level.TwoPlayerCompatible)
-			LevelData.Blocks[SelectedBlock].MakeInterlacedCompatible();
+				LevelData.Blocks[SelectedBlock].MakeInterlacedCompatible();
 			LevelData.RedrawBlock(SelectedBlock, true);
 			DrawLevel();
 			DrawBlockPicture();
@@ -4199,7 +4202,7 @@ namespace SonicRetro.SonLVL.GUI
 				foreach (Block block in LevelData.Blocks)
 					for (int y = 0; y < 2; y++)
 						for (int x = 0; x < 2; x++)
-							if (block.Tiles[x, y].Palette == mouseColor.Y && !tiles.Contains(block.Tiles[x,y].Tile))
+							if (block.Tiles[x, y].Palette == mouseColor.Y && !tiles.Contains(block.Tiles[x, y].Tile))
 							{
 								int t = block.Tiles[x, y].Tile;
 								byte[] til = LevelData.Tiles[t];
@@ -4473,7 +4476,7 @@ namespace SonicRetro.SonLVL.GUI
 			{
 				int blockmax = LevelData.GetBlockMax();
 				pasteOverToolStripMenuItem.Enabled = Clipboard.ContainsData(typeof(Block).AssemblyQualifiedName) || Clipboard.ContainsData(typeof(BlockCopyData).AssemblyQualifiedName);
-				pasteBeforeToolStripMenuItem.Enabled = pasteOverToolStripMenuItem.Enabled && LevelData.Blocks.Count <  blockmax;
+				pasteBeforeToolStripMenuItem.Enabled = pasteOverToolStripMenuItem.Enabled && LevelData.Blocks.Count < blockmax;
 				pasteAfterToolStripMenuItem.Enabled = pasteBeforeToolStripMenuItem.Enabled;
 				insertAfterToolStripMenuItem.Enabled = LevelData.Blocks.Count < blockmax;
 				insertBeforeToolStripMenuItem.Enabled = insertAfterToolStripMenuItem.Enabled;
@@ -7036,7 +7039,7 @@ namespace SonicRetro.SonLVL.GUI
 			int blky = (y % LevelData.Level.ChunkHeight) / 16;
 			int colx = x % 16;
 			int coly = y % 16;
-			
+
 			ChunkBlock blk = LevelData.Chunks[LevelData.Layout.FGLayout[cnkx, cnky]].Blocks[blkx, blky];
 			Solidity solid;
 			int colind;
@@ -8877,7 +8880,7 @@ namespace SonicRetro.SonLVL.GUI
 			// kind of hacky but whatever
 			if (LevelData.Level.LoopChunks != null)
 				foreach (byte ch in LevelData.Level.LoopChunks)
-					chunksused[ch+1] = true;
+					chunksused[ch + 1] = true;
 			LevelData.RemapLayouts((layout, x, y) =>
 			{
 				if (layout[x, y] < chunksused.Length)
@@ -8984,7 +8987,7 @@ namespace SonicRetro.SonLVL.GUI
 				int cnt = 0;
 				for (int y = 0; y < LevelData.FGHeight; y++)
 					for (int x = 0; x < LevelData.FGWidth; x++)
-						if (LevelData.Layout.FGLayout[x,y] == fc)
+						if (LevelData.Layout.FGLayout[x, y] == fc)
 						{
 							LevelData.Layout.FGLayout[x, y] = rc;
 							cnt++;
@@ -9496,8 +9499,8 @@ namespace SonicRetro.SonLVL.GUI
 				case ArtTab.Tiles:
 					using (SaveFileDialog a = new SaveFileDialog() { FileName = (useHexadecimalIndexesToolStripMenuItem.Checked ? SelectedTile.ToString("X2") : SelectedTile.ToString()) + ".png", Filter = "PNG Images|*.png" })
 						if (a.ShowDialog() == DialogResult.OK)
-								LevelData.TileToBmp4bpp(LevelData.Tiles[SelectedTile], 0, SelectedColor.Y, transparentBackgroundToolStripMenuItem.Checked)
-									.Save(a.FileName);
+							LevelData.TileToBmp4bpp(LevelData.Tiles[SelectedTile], 0, SelectedColor.Y, transparentBackgroundToolStripMenuItem.Checked)
+								.Save(a.FileName);
 					break;
 			}
 		}

--- a/SonLVLAPI/GameInfo.cs
+++ b/SonLVLAPI/GameInfo.cs
@@ -13,6 +13,8 @@ namespace SonicRetro.SonLVL.API
 		[DefaultValue(EngineVersion.S2)]
 		[IniName("version")]
 		public EngineVersion EngineVersion { get; set; }
+		[IniName("gamename")]
+		public string GameName { get; set; }
 		[IniName("objlst")]
 		[IniCollection(IniCollectionMode.SingleLine, Format = "|")]
 		public string[] ObjectList { get; set; }
@@ -100,6 +102,12 @@ namespace SonicRetro.SonLVL.API
 		public string Angles { get; set; }
 		[IniName("2pcompat")]
 		public bool TwoPlayerCompatible { get; set; }
+		// extra data like unknown image, icon, etc.
+		[IniName("sonlvlicon")]
+		public string SonLVLIconPath { get; set; }
+		[IniName("unknownimg")]
+		public string UnknownImgPath { get; set; }
+		// end of extra data
 		[IniName("buildscr")]
 		public string BuildScript { get; set; }
 		[IniName("romfile")]
@@ -123,6 +131,8 @@ namespace SonicRetro.SonLVL.API
 				result.MappingsVersion = result.EngineVersion;
 			if (result.DPLCVersion == EngineVersion.Invalid)
 				result.DPLCVersion = result.MappingsVersion;
+			if (result.GameName == null)
+				result.GameName = result.EngineVersion.ToString();
 			return result;
 		}
 

--- a/SonLVLAPI/LevelData.cs
+++ b/SonLVLAPI/LevelData.cs
@@ -122,6 +122,8 @@ namespace SonicRetro.SonLVL.API
 					UnknownImg = Properties.Resources.UnknownImg3K.Copy();
 					littleendian = true;
 					break;
+				case EngineVersion.Custom:
+					throw new NotImplementedException("Engine is custom, and \"unknownimg\" is missing in INI file.");
 				default:
 					throw new NotImplementedException("Game type " + Game.EngineVersion.ToString() + " is not supported!");
 			}
@@ -154,6 +156,10 @@ namespace SonicRetro.SonLVL.API
 				case EngineVersion.SKC:
 					UnknownImg = Properties.Resources.UnknownImg3K.Copy();
 					littleendian = true;
+					break;
+				case EngineVersion.Custom:
+					if (Game.UnknownImgPath == null)
+						throw new NotImplementedException("Engine is custom, and \"unknownimg\" is missing in INI file.");
 					break;
 				default:
 					throw new NotImplementedException("Game type " + Level.EngineVersion.ToString() + " is not supported!");

--- a/SonLVLAPI/LevelData.cs
+++ b/SonLVLAPI/LevelData.cs
@@ -99,7 +99,11 @@ namespace SonicRetro.SonLVL.API
 			Log("Opening INI file \"" + filename + "\"...");
 			Game = GameInfo.Load(filename);
 			Environment.CurrentDirectory = Path.GetDirectoryName(filename);
-			switch (Game.EngineVersion)
+			if(Game.UnknownImgPath != null)
+			{
+				UnknownImg = new Bitmap(Game.UnknownImgPath);
+			}
+			else switch (Game.EngineVersion)
 			{
 				case EngineVersion.S1:
 				case EngineVersion.SCD:
@@ -154,6 +158,9 @@ namespace SonicRetro.SonLVL.API
 				default:
 					throw new NotImplementedException("Game type " + Level.EngineVersion.ToString() + " is not supported!");
 			}
+			// support for custom unknown images
+			if(Game.UnknownImgPath != null)
+				UnknownImg = new Bitmap(Game.UnknownImgPath);
 			UnknownSprite = new Sprite(new BitmapBits(UnknownImg), true, -8, -7);
 			Log("Loading " + Level.DisplayName + "...");
 			if ((Level.ChunkWidth & 15) != 0)

--- a/SonPLN/MainForm.cs
+++ b/SonPLN/MainForm.cs
@@ -193,6 +193,8 @@ namespace SonicRetro.SonLVL.SonPLN
 					case EngineVersion.S2:
 					case EngineVersion.S2NA:
 					case EngineVersion.S3K:
+					case EngineVersion.Chaotix:
+					case EngineVersion.Custom:		// assuming it's a Mega Drive engine...
 						break;
 					case EngineVersion.SKC:
 						LevelData.littleendian = true;


### PR DESCRIPTION
Previously, SonLVL didn't support properly EngineVersion.Custom.
I changed SonLVL and the API quite a bit so it supports custom engines with the following requirements:
1. User must specify "chunkfmt", "objectfmt", "ringfmt", etc. since they don't inherit from "version".
2. User must specify "unknownimg" for the question mark image (should be indexed colors).

I also added those properties that can be specified in the INI file:
"gamename" - what SonLVL will display on title bar (instead of EngineVersion).
"unknownimg" -  path to indexed color image file for unknown object types (required for custom engines).
"sonlvlicon" - optional path to *.ico file for SonLVL to change icon when loading INI.