### PR TITLE
Fix an oversight in GetChunkMax

### DIFF
--- a/SonLVLAPI/LevelData.cs
+++ b/SonLVLAPI/LevelData.cs
@@ -3058,7 +3058,7 @@ namespace SonicRetro.SonLVL.API
 		public static int GetChunkMax()
 		{
 			int chunkmax = 0x100;
-			if (Game.BlockMax.HasValue)
+			if (Game.ChunkMax.HasValue)
 				chunkmax = Game.ChunkMax.Value;
 			return chunkmax;
 		}


### PR DESCRIPTION
There is an oversight in GetChunkMax of the previous merged pull request, that SonLVL checks if BlockMax has a value, and not ChunkMax. This can result in problems when BlockMax is changed in the SonLVL INI file.