### PR TITLE
S1 - Fix Platform "SwitchID" Property

### DIFF
--- a/INI Files/Sonic 1 2005 INIs/GHZ/Platform.xml
+++ b/INI Files/Sonic 1 2005 INIs/GHZ/Platform.xml
@@ -26,7 +26,7 @@
   </Subtypes>
   <Properties>
     <BitsProperty name="Movement" type="PlatformMovement" startbit="0" length="4"/>
-    <BitsProperty name="SwitchID" displayname="Switch ID" type="byte" startbit="4" length="4"/>
+    <BitsProperty name="SwitchID" displayname="Switch ID" type="int" startbit="4" length="4"/>
   </Properties>
   <Enums>
     <Enum name="PlatformMovement">

--- a/INI Files/Sonic 1 2005 INIs/SLZ/Platform.xml
+++ b/INI Files/Sonic 1 2005 INIs/SLZ/Platform.xml
@@ -21,7 +21,7 @@
   </Subtypes>
   <Properties>
     <BitsProperty name="Movement" type="PlatformMovement" startbit="0" length="4"/>
-    <BitsProperty name="SwitchID" displayname="Switch ID" type="byte" startbit="4" length="4"/>
+    <BitsProperty name="SwitchID" displayname="Switch ID" type="int" startbit="4" length="4"/>
   </Properties>
   <Enums>
     <Enum name="PlatformMovement">

--- a/INI Files/Sonic 1 2005 INIs/SYZ/Platform.xml
+++ b/INI Files/Sonic 1 2005 INIs/SYZ/Platform.xml
@@ -21,7 +21,7 @@
   </Subtypes>
   <Properties>
     <BitsProperty name="Movement" type="PlatformMovement" startbit="0" length="4"/>
-    <BitsProperty name="SwitchID" displayname="Switch ID" type="byte" startbit="4" length="4"/>
+    <BitsProperty name="SwitchID" displayname="Switch ID" type="int" startbit="4" length="4"/>
   </Properties>
   <Enums>
     <Enum name="PlatformMovement">

--- a/INI Files/Sonic 1 Git INIs/GHZ/Platform.xml
+++ b/INI Files/Sonic 1 Git INIs/GHZ/Platform.xml
@@ -26,7 +26,7 @@
   </Subtypes>
   <Properties>
     <BitsProperty name="Movement" type="PlatformMovement" startbit="0" length="4"/>
-    <BitsProperty name="SwitchID" displayname="Switch ID" type="byte" startbit="4" length="4"/>
+    <BitsProperty name="SwitchID" displayname="Switch ID" type="int" startbit="4" length="4"/>
   </Properties>
   <Enums>
     <Enum name="PlatformMovement">

--- a/INI Files/Sonic 1 Git INIs/SLZ/Platform.xml
+++ b/INI Files/Sonic 1 Git INIs/SLZ/Platform.xml
@@ -21,7 +21,7 @@
   </Subtypes>
   <Properties>
     <BitsProperty name="Movement" type="PlatformMovement" startbit="0" length="4"/>
-    <BitsProperty name="SwitchID" displayname="Switch ID" type="byte" startbit="4" length="4"/>
+    <BitsProperty name="SwitchID" displayname="Switch ID" type="int" startbit="4" length="4"/>
   </Properties>
   <Enums>
     <Enum name="PlatformMovement">

--- a/INI Files/Sonic 1 Git INIs/SYZ/Platform.xml
+++ b/INI Files/Sonic 1 Git INIs/SYZ/Platform.xml
@@ -21,7 +21,7 @@
   </Subtypes>
   <Properties>
     <BitsProperty name="Movement" type="PlatformMovement" startbit="0" length="4"/>
-    <BitsProperty name="SwitchID" displayname="Switch ID" type="byte" startbit="4" length="4"/>
+    <BitsProperty name="SwitchID" displayname="Switch ID" type="int" startbit="4" length="4"/>
   </Properties>
   <Enums>
     <Enum name="PlatformMovement">

--- a/INI Files/Sonic 1 Project 128 INIs/GHZ/Platform.xml
+++ b/INI Files/Sonic 1 Project 128 INIs/GHZ/Platform.xml
@@ -26,7 +26,7 @@
   </Subtypes>
   <Properties>
     <BitsProperty name="Movement" type="PlatformMovement" startbit="0" length="4"/>
-    <BitsProperty name="SwitchID" displayname="Switch ID" type="byte" startbit="4" length="4"/>
+    <BitsProperty name="SwitchID" displayname="Switch ID" type="int" startbit="4" length="4"/>
   </Properties>
   <Enums>
     <Enum name="PlatformMovement">

--- a/INI Files/Sonic 1 Project 128 INIs/SLZ/Platform.xml
+++ b/INI Files/Sonic 1 Project 128 INIs/SLZ/Platform.xml
@@ -21,7 +21,7 @@
   </Subtypes>
   <Properties>
     <BitsProperty name="Movement" type="PlatformMovement" startbit="0" length="4"/>
-    <BitsProperty name="SwitchID" displayname="Switch ID" type="byte" startbit="4" length="4"/>
+    <BitsProperty name="SwitchID" displayname="Switch ID" type="int" startbit="4" length="4"/>
   </Properties>
   <Enums>
     <Enum name="PlatformMovement">

--- a/INI Files/Sonic 1 Project 128 INIs/SYZ/Platform.xml
+++ b/INI Files/Sonic 1 Project 128 INIs/SYZ/Platform.xml
@@ -21,7 +21,7 @@
   </Subtypes>
   <Properties>
     <BitsProperty name="Movement" type="PlatformMovement" startbit="0" length="4"/>
-    <BitsProperty name="SwitchID" displayname="Switch ID" type="byte" startbit="4" length="4"/>
+    <BitsProperty name="SwitchID" displayname="Switch ID" type="int" startbit="4" length="4"/>
   </Properties>
   <Enums>
     <Enum name="PlatformMovement">


### PR DESCRIPTION
Fixes the error caused by attempting to change a Platform's "SwitchID" property in Sonic 1.