### PR TITLE
SonLVL - Use a Graphics Buffer for drawing

### DIFF
--- a/SonLVL/MainForm.cs
+++ b/SonLVL/MainForm.cs
@@ -1978,7 +1978,8 @@ namespace SonicRetro.SonLVL.GUI
 					}
 					break;
 			}
-			panel.PanelGraphics.DrawImage(LevelBmp, 0, 0, panel.PanelWidth, panel.PanelHeight);
+			panel.PanelGraphicsBuffer.Graphics.DrawImage(LevelBmp, 0, 0, panel.PanelWidth, panel.PanelHeight);
+			panel.PanelGraphicsBuffer.Render(panel.PanelGraphics);
 		}
 
 		public Rectangle DrawHUDStr(int x, int y, string str)

--- a/SonLVL/ScrollingPanel.cs
+++ b/SonLVL/ScrollingPanel.cs
@@ -34,6 +34,9 @@ namespace SonicRetro.SonLVL
 		public Graphics PanelGraphics { get; private set; }
 
 		[Browsable(false)]
+		public BufferedGraphics PanelGraphicsBuffer { get; private set; }
+
+		[Browsable(false)]
 		public int PanelWidth { get { return panel.Width; } }
 
 		[Browsable(false)]
@@ -217,12 +220,20 @@ namespace SonicRetro.SonLVL
 		{
 			PanelGraphics = panel.CreateGraphics();
 			PanelGraphics.SetOptions();
+
+			using (Graphics graphics = CreateGraphics())
+				PanelGraphicsBuffer = BufferedGraphicsManager.Current.Allocate(graphics, new Rectangle(0, 0, PanelWidth, PanelHeight));
+			PanelGraphicsBuffer.Graphics.SetOptions();
 		}
 
 		private void panel_Resize(object sender, EventArgs e)
 		{
 			PanelGraphics = panel.CreateGraphics();
 			PanelGraphics.SetOptions();
+
+			using (Graphics graphics = CreateGraphics())
+				PanelGraphicsBuffer = BufferedGraphicsManager.Current.Allocate(graphics, new Rectangle(0, 0, PanelWidth, PanelHeight));
+			PanelGraphicsBuffer.Graphics.SetOptions();
 		}
 
 		public Point PanelPointToClient(Point p)


### PR DESCRIPTION
Adjusts SonLVL's drawing to use a graphics buffer. This provides faster drawing as well as decreased screen tearing, especially when the editor is zoomed out. There are likely better methods of implementation, but even with this as it is right now, it already provides a very noticeable speed increase.