### PR TITLE
SonPLN - Various Updates

### DIFF
--- a/SonPLN/MainForm.cs
+++ b/SonPLN/MainForm.cs
@@ -299,6 +299,7 @@ namespace SonicRetro.SonLVL.SonPLN
 			((ToolStripMenuItem)sender).Checked = true;
 			Enabled = false;
 			UseWaitCursor = true;
+			FGSelection = Rectangle.Empty;
 			levelname = (string)((ToolStripMenuItem)sender).Tag;
 			level = game.GetLevelInfo(levelname);
 			Text = $"SonPLN - {game.EngineVersion} - Loading {level.DisplayName}...";
@@ -974,10 +975,14 @@ namespace SonicRetro.SonLVL.SonPLN
 			LevelGfx.SetOptions();
 			Point pnlcur = panel.PanelPointToClient(Cursor.Position);
 			if (!selecting && SelectedTile < LevelData.Tiles.Count)
+			{
+				tile.Flip(xFlip.Checked, yFlip.Checked);
 				LevelGfx.DrawImage(tile.ToBitmap(curpal),
 				new Rectangle(((((int)(pnlcur.X / ZoomLevel) + camera.X) / 8) * 8) - camera.X, ((((int)(pnlcur.Y / ZoomLevel) + camera.Y) / 8) * 8) - camera.Y, 8, 8),
 				0, 0, 8, 8,
 				GraphicsUnit.Pixel, imageTransparency);
+				tile.Flip(xFlip.Checked, yFlip.Checked);
+			}
 			if (!selection.IsEmpty)
 			{
 				Rectangle selbnds = selection.Scale(8, 8);
@@ -1064,6 +1069,33 @@ namespace SonicRetro.SonLVL.SonPLN
 					if (!loaded) return;
 					foregroundPanel.HScrollValue = Math.Max((int)Math.Min(foregroundPanel.HScrollValue + step, foregroundPanel.HScrollMaximum - foregroundPanel.HScrollLargeChange + 1), foregroundPanel.HScrollMinimum);
 					break;
+				case Keys.C:
+					if (!loaded) return;
+					if (e.Control)
+						copyToolStripMenuItem1_Click(this, EventArgs.Empty);
+					else
+						priority.Checked = !priority.Checked;
+					break;
+				case Keys.X:
+					if (!loaded) return;
+					if (e.Control)
+						cutToolStripMenuItem1_Click(this, EventArgs.Empty);
+					else
+						xFlip.Checked = !xFlip.Checked;
+					break;
+				case Keys.V:
+					if (!loaded || !e.Control || FGSelection.IsEmpty) return;
+					pasteOnceToolStripMenuItem_Click(this, EventArgs.Empty);
+					break;
+				case Keys.Y:
+				case Keys.S:
+					if (!loaded || e.Control) return;
+					yFlip.Checked = !yFlip.Checked;
+					break;
+				case Keys.P:
+					if (!loaded || e.Control) return;
+					priority.Checked = !priority.Checked;
+					break;
 				case Keys.A:
 					if (!loaded) return;
 					SelectedTile = SelectedTile == 0 ? LevelData.Tiles.Count - 1 : SelectedTile - 1;
@@ -1076,6 +1108,10 @@ namespace SonicRetro.SonLVL.SonPLN
 					break;
 				case Keys.I:
 					enableGridToolStripMenuItem.Checked = !enableGridToolStripMenuItem.Checked;
+					DrawLevel();
+					break;
+				case Keys.Escape:
+					FGSelection = Rectangle.Empty;
 					DrawLevel();
 					break;
 				case Keys.OemMinus:
@@ -1913,11 +1949,12 @@ namespace SonicRetro.SonLVL.SonPLN
 		private void pasteOnceToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			PatternIndex[,] section = (PatternIndex[,])Clipboard.GetData(typeof(PatternIndex[,]).AssemblyQualifiedName);
-			int w = Math.Min(section.GetLength(0), planemap.GetLength(0) - menuLoc.X);
-			int h = Math.Min(section.GetLength(1), planemap.GetLength(1) - menuLoc.Y);
+			int w = Math.Min(section.GetLength(0), planemap.GetLength(0) - FGSelection.X);
+			int h = Math.Min(section.GetLength(1), planemap.GetLength(1) - FGSelection.Y);
 			for (int y = 0; y < h; y++)
 				for (int x = 0; x < w; x++)
 					planemap[x + menuLoc.X, y + menuLoc.Y] = section[x, y].Clone();
+			FGSelection = new Rectangle(menuLoc.X, menuLoc.Y, w, h);
 			DrawLevel();
 		}
 

--- a/SonPLN/MainForm.cs
+++ b/SonPLN/MainForm.cs
@@ -129,6 +129,10 @@ namespace SonicRetro.SonLVL.SonPLN
 			mainMenuStrip.Visible = Settings.ShowMenu;
 			enableDraggingPaletteButton.Checked = Settings.EnableDraggingPalette;
 			enableDraggingTilesButton.Checked = Settings.EnableDraggingTiles;
+
+			if (Settings.TilesTabWidth > 0)
+				splitContainer2.SplitterDistance = Math.Max(splitContainer2.Width - Settings.TilesTabWidth, 200);
+
 			if (Settings.MRUList == null)
 				Settings.MRUList = new List<string>();
 			List<string> mru = new List<string>();
@@ -175,6 +179,7 @@ namespace SonicRetro.SonLVL.SonPLN
 				Settings.ShowMenu = mainMenuStrip.Visible;
 				Settings.EnableDraggingPalette = enableDraggingPaletteButton.Checked;
 				Settings.EnableDraggingTiles = enableDraggingTilesButton.Checked;
+				Settings.TilesTabWidth = splitContainer2.Width - splitContainer2.SplitterDistance;
 				Settings.Save();
 			}
 		}

--- a/SonPLN/MainForm.cs
+++ b/SonPLN/MainForm.cs
@@ -509,10 +509,10 @@ namespace SonicRetro.SonLVL.SonPLN
 			UpdateScrollBars();
 			foregroundPanel.HScrollValue = 0;
 			foregroundPanel.HScrollSmallChange = 8;
-			foregroundPanel.HScrollLargeChange = 128;
+			foregroundPanel.HScrollLargeChange = 32;
 			foregroundPanel.VScrollValue = 0;
 			foregroundPanel.VScrollSmallChange = 8;
-			foregroundPanel.VScrollLargeChange = 128;
+			foregroundPanel.VScrollLargeChange = 32;
 			foregroundPanel.HScrollEnabled = true;
 			foregroundPanel.VScrollEnabled = true;
 			switch (level.PaletteFormat)
@@ -986,8 +986,8 @@ namespace SonicRetro.SonLVL.SonPLN
 
 		private void UpdateScrollBars()
 		{
-			foregroundPanel.HScrollMaximum = (int)Math.Max((planemap.GetLength(0) * 8) + foregroundPanel.HScrollLargeChange - (foregroundPanel.PanelWidth / ZoomLevel), 0);
-			foregroundPanel.VScrollMaximum = (int)Math.Max((planemap.GetLength(1) * 8) + foregroundPanel.VScrollLargeChange - (foregroundPanel.PanelHeight / ZoomLevel), 0);
+			foregroundPanel.HScrollMaximum = (int)Math.Max((planemap.GetLength(0) * 8) + foregroundPanel.HScrollLargeChange - (foregroundPanel.PanelWidth / ZoomLevel), foregroundPanel.HScrollLargeChange - 1);
+			foregroundPanel.VScrollMaximum = (int)Math.Max((planemap.GetLength(1) * 8) + foregroundPanel.VScrollLargeChange - (foregroundPanel.PanelHeight / ZoomLevel), foregroundPanel.VScrollLargeChange - 1);
 		}
 
 		Rectangle prevbnds;
@@ -1044,7 +1044,7 @@ namespace SonicRetro.SonLVL.SonPLN
 					break;
 				case Keys.Down:
 					if (!loaded) return;
-					foregroundPanel.VScrollValue = (int)Math.Min(foregroundPanel.VScrollValue + step, foregroundPanel.VScrollMaximum - 8 + 1);
+					foregroundPanel.VScrollValue = Math.Max((int)Math.Min(foregroundPanel.VScrollValue + step, foregroundPanel.VScrollMaximum - foregroundPanel.VScrollLargeChange + 1), foregroundPanel.VScrollMinimum);
 					break;
 				case Keys.Left:
 					if (!loaded) return;
@@ -1052,7 +1052,7 @@ namespace SonicRetro.SonLVL.SonPLN
 					break;
 				case Keys.Right:
 					if (!loaded) return;
-					foregroundPanel.HScrollValue = (int)Math.Min(foregroundPanel.HScrollValue + step, foregroundPanel.HScrollMaximum - 8 + 1);
+					foregroundPanel.HScrollValue = Math.Max((int)Math.Min(foregroundPanel.HScrollValue + step, foregroundPanel.HScrollMaximum - foregroundPanel.HScrollLargeChange + 1), foregroundPanel.HScrollMinimum);
 					break;
 				case Keys.A:
 					if (!loaded) return;

--- a/SonPLN/MainForm.cs
+++ b/SonPLN/MainForm.cs
@@ -1646,7 +1646,9 @@ namespace SonicRetro.SonLVL.SonPLN
 
 		private void cutTilesToolStripMenuItem_Click(object sender, EventArgs e)
 		{
-			Clipboard.SetData("SonLVLTile", LevelData.Tiles[SelectedTile]);
+			DataObject data = new DataObject("SonLVLTile", LevelData.Tiles[SelectedTile]);
+			data.SetImage(tile.ToBitmap(curpal));
+			Clipboard.SetDataObject(data);
 			DeleteTile();
 		}
 
@@ -1668,7 +1670,9 @@ namespace SonicRetro.SonLVL.SonPLN
 
 		private void copyTilesToolStripMenuItem_Click(object sender, EventArgs e)
 		{
-			Clipboard.SetData("SonLVLTile", LevelData.Tiles[SelectedTile]);
+			DataObject data = new DataObject("SonLVLTile", LevelData.Tiles[SelectedTile]);
+			data.SetImage(tile.ToBitmap(curpal));
+			Clipboard.SetDataObject(data);
 		}
 
 		private void InsertTile()
@@ -1879,6 +1883,9 @@ namespace SonicRetro.SonLVL.SonPLN
 
 		private void cutToolStripMenuItem1_Click(object sender, EventArgs e)
 		{
+			DataObject data = new DataObject();
+			data.SetImage(DrawPlane(new Rectangle(FGSelection.Left * 8, FGSelection.Top * 8, FGSelection.Width * 8, FGSelection.Height * 8), true, true).ToBitmap(LevelImgPalette));
+			
 			PatternIndex[,] layoutsection = new PatternIndex[FGSelection.Width, FGSelection.Height];
 			for (int y = 0; y < FGSelection.Height; y++)
 				for (int x = 0; x < FGSelection.Width; x++)
@@ -1886,7 +1893,9 @@ namespace SonicRetro.SonLVL.SonPLN
 					layoutsection[x, y] = planemap[x + FGSelection.X, y + FGSelection.Y].Clone();
 					planemap[x + FGSelection.X, y + FGSelection.Y] = new PatternIndex();
 				}
-			Clipboard.SetData(typeof(PatternIndex[,]).AssemblyQualifiedName, layoutsection);
+
+			data.SetData(typeof(PatternIndex[,]).AssemblyQualifiedName, layoutsection);
+			Clipboard.SetDataObject(data);
 			DrawLevel();
 		}
 
@@ -1896,7 +1905,9 @@ namespace SonicRetro.SonLVL.SonPLN
 			for (int y = 0; y < FGSelection.Height; y++)
 				for (int x = 0; x < FGSelection.Width; x++)
 					layoutsection[x, y] = planemap[x + FGSelection.X, y + FGSelection.Y].Clone();
-			Clipboard.SetData(typeof(PatternIndex[,]).AssemblyQualifiedName, layoutsection);
+			DataObject data = new DataObject(typeof(PatternIndex[,]).AssemblyQualifiedName, layoutsection);
+			data.SetImage(DrawPlane(new Rectangle(FGSelection.Left * 8, FGSelection.Top * 8, FGSelection.Width * 8, FGSelection.Height * 8), true, true).ToBitmap(LevelImgPalette));
+			Clipboard.SetDataObject(data);
 		}
 
 		private void pasteOnceToolStripMenuItem_Click(object sender, EventArgs e)

--- a/SonPLN/MainForm.cs
+++ b/SonPLN/MainForm.cs
@@ -949,16 +949,26 @@ namespace SonicRetro.SonLVL.SonPLN
 				default:
 					return;
 			}
+
 			Point camera = new Point(panel.HScrollValue, panel.VScrollValue);
 			Rectangle dispRect = new Rectangle(camera.X, camera.Y, (int)(panel.PanelWidth / ZoomLevel), (int)(panel.PanelHeight / ZoomLevel));
 			LevelImg8bpp = DrawPlane(dispRect, true, true);
+
 			if (enableGridToolStripMenuItem.Checked)
 			{
-				for (int x = (8 - (camera.X % 8)) % 8; x < LevelImg8bpp.Width; x += 8)
-					LevelImg8bpp.DrawLine(ColorGrid, x, 0, x, LevelImg8bpp.Height - 1);
-				for (int y = (8 - (camera.Y % 8)) % 8; y < LevelImg8bpp.Height; y += 8)
-					LevelImg8bpp.DrawLine(ColorGrid, 0, y, LevelImg8bpp.Width - 1, y);
+				// Let's constrain the grid to stay within the mapping bounds
+				int length = Math.Min(LevelImg8bpp.Height, (planemap.GetLength(1) * 8) - camera.Y);
+				int end = Math.Min(camera.X + (LevelImg8bpp.Width - 1), planemap.GetLength(0) * 8);
+
+				for (int x = camera.X & ~7; x <= end; x += 8)
+					LevelImg8bpp.DrawLine(ColorGrid, x - camera.X, 0, x - camera.X, length);
+
+				length = Math.Min(LevelImg8bpp.Width, (planemap.GetLength(0) * 8) - camera.X);
+				end = Math.Min(camera.Y + (LevelImg8bpp.Height - 1), planemap.GetLength(1) * 8);
+				for (int y = camera.Y & ~7; y <= end; y += 8)
+					LevelImg8bpp.DrawLine(ColorGrid, 0, y - camera.Y, length, y - camera.Y);
 			}
+
 			LevelBmp = LevelImg8bpp.ToBitmap(LevelImgPalette).To32bpp();
 			LevelGfx = Graphics.FromImage(LevelBmp);
 			LevelGfx.SetOptions();

--- a/SonPLN/ScrollingPanel.cs
+++ b/SonPLN/ScrollingPanel.cs
@@ -152,8 +152,8 @@ namespace SonicRetro.SonLVL.SonPLN
 			}
 			if (bPan) {
 				Point p = origScroll - (Size)(e.Location - (Size)origPoint);
-				VScrollValue = (int)Math.Min(Math.Max(p.Y, VScrollMinimum), VScrollMaximum);
-				HScrollValue = (int)Math.Min(Math.Max(p.X, HScrollMinimum), HScrollMaximum);
+				VScrollValue = Math.Min(Math.Max(p.Y, VScrollMinimum), VScrollMaximum - VScrollLargeChange + 1);
+				HScrollValue = Math.Min(Math.Max(p.X, HScrollMinimum), HScrollMaximum - HScrollLargeChange + 1);
 			}
 			PanelMouseMove(sender, e);
 		}
@@ -176,10 +176,10 @@ namespace SonicRetro.SonLVL.SonPLN
 			}
 
 			if(shiftHeld && VScrollEnabled) {
-				VScrollValue = (int)Math.Min(Math.Max(VScrollValue + delta, VScrollMinimum), VScrollMaximum);
+				VScrollValue = Math.Min(Math.Max(VScrollValue + delta, VScrollMinimum), VScrollMaximum - VScrollLargeChange + 1);
 			}
 			else if(!shiftHeld && HScrollEnabled) {
-				HScrollValue = (int)Math.Min(Math.Max(HScrollValue + delta, HScrollMinimum), HScrollMaximum);
+				HScrollValue = Math.Min(Math.Max(HScrollValue + delta, HScrollMinimum), HScrollMaximum - HScrollLargeChange + 1);
 			}
 		}
 

--- a/SonPLN/Settings.cs
+++ b/SonPLN/Settings.cs
@@ -30,6 +30,7 @@ namespace SonicRetro.SonLVL.SonPLN
 		public bool ExportArtCollisionPriority { get; set; }
 		[DefaultValue("1x")]
 		public string ZoomLevel { get; set; }
+		public int TilesTabWidth { get; set; }
 		public Tab CurrentTab { get; set; }
 		public WindowMode WindowMode { get; set; }
 		[DefaultValue(true)]


### PR DESCRIPTION
Adds a couple of features to SonPLN, and fixes a handful of bugs.

Additions:
- Remember the width of the tiles tab list when closing and reopening the editor. (closes #171)
- Add extra keyboard shortcuts
  - CTRL+C: Copy selected area
  - CTRL+X: Cut selected area
  - CTRL+V: Paste (once) within selected area
  - C/P: Toggle selected tile priority
  - X: Toggle selected tile x flip
  - S/Y: Toggle selected tile y flip
  - Escape: Cancel currently selection
- When copying data, copy an image render of it as well (so ie you can copy a section of a mapping and paste it straight into paint.net, but the same clipboard still holds the SonPLN data at the same time)
  - Works for both tiles as well as entire mapping sections

Smaller Tweaks:
- Flip the selected tile in the mapping editor preview
- When pasting once, select the entire pasted area afterwards
- Contain the grid within mapping bounds (closes #94)

Bugfixes:
- Reset current selection when loading a new mapping (previously, invalid selections too large for the current mapping could be retained when switching mappings)
- Fix scroll bound limits being inconsistent between the scroll wheel, arrow keys, and clicking on the scroll bar.
- Fixes the error that occurred when pressing the down or right arrow keys to go past the mapping bounds (fixes #92)

