### PR TITLE
SonLVL - Copying Enhancements + Bugfixes

### DIFF
--- a/SonLVL/MainForm.Designer.cs
+++ b/SonLVL/MainForm.Designer.cs
@@ -2978,6 +2978,7 @@ namespace SonicRetro.SonLVL.GUI
             this.CollisionSelector.Size = new System.Drawing.Size(449, 462);
             this.CollisionSelector.TabIndex = 2;
             this.CollisionSelector.SelectedIndexChanged += new System.EventHandler(this.CollisionSelector_SelectedIndexChanged);
+            this.CollisionSelector.KeyDown += new System.Windows.Forms.KeyEventHandler(this.CollisionSelector_KeyDown);
             this.CollisionSelector.MouseDown += new System.Windows.Forms.MouseEventHandler(this.CollisionSelector_MouseDown);
             // 
             // tableLayoutPanel8

--- a/SonLVL/MainForm.cs
+++ b/SonLVL/MainForm.cs
@@ -8316,10 +8316,21 @@ namespace SonicRetro.SonLVL.GUI
 				Point clientPoint = ChunkSelector.PointToClient(new Point(e.X, e.Y));
 				ushort newindex = (ushort)ChunkSelector.GetItemAtPoint(clientPoint);
 				ushort oldindex = (ushort)(int)e.Data.GetData("SonLVLChunkIndex_" + pid);
-				if (newindex == oldindex) return;
+				
+				if (newindex == oldindex)
+				{
+					ChunkSelector.Invalidate();
+					return;
+				}
+
 				if ((ModifierKeys & Keys.Control) == Keys.Control)
 				{
-					if (newindex == LevelData.Chunks.Count) return;
+					if (newindex == LevelData.Chunks.Count)
+					{
+						ChunkSelector.Invalidate();
+						return;
+					}
+
 					LevelData.Chunks.Swap(oldindex, newindex);
 					LevelData.ChunkSprites.Swap(oldindex, newindex);
 					LevelData.ChunkBmps.Swap(oldindex, newindex);
@@ -8337,7 +8348,12 @@ namespace SonicRetro.SonLVL.GUI
 				}
 				else
 				{
-					if (newindex == oldindex + 1) return;
+					if (newindex == oldindex + 1)
+					{
+						ChunkSelector.Invalidate();
+						return;
+					}
+
 					LevelData.Chunks.Move(oldindex, newindex);
 					LevelData.ChunkSprites.Move(oldindex, newindex);
 					LevelData.ChunkBmps.Move(oldindex, newindex);
@@ -8439,10 +8455,20 @@ namespace SonicRetro.SonLVL.GUI
 				Point clientPoint = BlockSelector.PointToClient(new Point(e.X, e.Y));
 				ushort newindex = (ushort)BlockSelector.GetItemAtPoint(clientPoint);
 				ushort oldindex = (ushort)(int)e.Data.GetData("SonLVLBlockIndex_" + pid);
-				if (newindex == oldindex) return;
+				if (newindex == oldindex)
+				{
+					BlockSelector.Invalidate();
+					return;
+				}
+
 				if ((ModifierKeys & Keys.Control) == Keys.Control)
 				{
-					if (newindex == LevelData.Blocks.Count) return;
+					if (newindex == LevelData.Blocks.Count)
+					{
+						BlockSelector.Invalidate();
+						return;
+					}
+
 					LevelData.Blocks.Swap(oldindex, newindex);
 					LevelData.BlockBmpBits.Swap(oldindex, newindex);
 					LevelData.BlockBmps.Swap(oldindex, newindex);
@@ -8465,7 +8491,12 @@ namespace SonicRetro.SonLVL.GUI
 				}
 				else
 				{
-					if (newindex == oldindex + 1) return;
+					if (newindex == oldindex + 1)
+					{
+						BlockSelector.Invalidate();
+						return;
+					}
+
 					LevelData.Blocks.Move(oldindex, newindex);
 					LevelData.BlockBmpBits.Move(oldindex, newindex);
 					LevelData.BlockBmps.Move(oldindex, newindex);
@@ -8572,10 +8603,20 @@ namespace SonicRetro.SonLVL.GUI
 				Point clientPoint = TileSelector.PointToClient(new Point(e.X, e.Y));
 				ushort newindex = (ushort)TileSelector.GetItemAtPoint(clientPoint);
 				ushort oldindex = (ushort)(int)e.Data.GetData("SonLVLTileIndex_" + pid);
-				if (newindex == oldindex) return;
+				if (newindex == oldindex)
+				{
+					TileSelector.Invalidate();
+					return;
+				}
+
 				if ((ModifierKeys & Keys.Control) == Keys.Control)
 				{
-					if (newindex == TileSelector.Images.Count) return;
+					if (newindex == TileSelector.Images.Count)
+					{
+						TileSelector.Invalidate();
+						return;
+					}
+
 					if (LevelData.Level.TwoPlayerCompatible)
 					{
 						LevelData.Tiles.Swap(oldindex * 2, newindex * 2);
@@ -8614,7 +8655,12 @@ namespace SonicRetro.SonLVL.GUI
 				}
 				else
 				{
-					if (newindex == oldindex + 1) return;
+					if (newindex == oldindex + 1)
+					{
+						TileSelector.Invalidate();
+						return;
+					}
+
 					if (LevelData.Level.TwoPlayerCompatible)
 					{
 						byte[] t1 = LevelData.Tiles[oldindex * 2];
@@ -9076,6 +9122,7 @@ namespace SonicRetro.SonLVL.GUI
 					else
 						LevelData.Chunks[SelectedChunk] = new Chunk((byte[])Clipboard.GetData(typeof(Chunk).AssemblyQualifiedName), 0);
 					LevelData.RedrawChunk(SelectedChunk);
+					ChunkSelector.Invalidate();
 					break;
 				case ArtTab.Blocks:
 					if (Clipboard.ContainsData(typeof(BlockCopyData).AssemblyQualifiedName))
@@ -9116,6 +9163,7 @@ namespace SonicRetro.SonLVL.GUI
 					else
 						LevelData.Blocks[SelectedBlock] = new Block((byte[])Clipboard.GetData(typeof(Block).AssemblyQualifiedName), 0);
 					LevelData.RedrawBlock(SelectedBlock, true);
+					BlockSelector.Invalidate();
 					break;
 				case ArtTab.Tiles:
 					if (LevelData.Level.TwoPlayerCompatible)
@@ -9147,6 +9195,7 @@ namespace SonicRetro.SonLVL.GUI
 					else
 						TileSelector.Images[SelectedTile] = LevelData.TileToBmp4bpp(LevelData.Tiles[SelectedTile], 0, SelectedColor.Y, false);
 					blockTileEditor.SelectedObjects = blockTileEditor.SelectedObjects;
+					TileSelector.Invalidate();
 					break;
 			}
 		}

--- a/SonLVL/MainForm.cs
+++ b/SonLVL/MainForm.cs
@@ -2205,6 +2205,43 @@ namespace SonicRetro.SonLVL.GUI
 						if (SelectedItems.Count > 0)
 							copyToolStripMenuItem_Click(sender, EventArgs.Empty);
 					break;
+				case Keys.D0:
+				case Keys.D1:
+					if (e.Control) return;
+					objGridSizeDropDownButton_DropDownItemClicked(this, new ToolStripItemClickedEventArgs(objGridSizeDropDownButton.DropDownItems[0]));
+					break;
+				case Keys.D2:
+					if (e.Control) return;
+					objGridSizeDropDownButton_DropDownItemClicked(this, new ToolStripItemClickedEventArgs(objGridSizeDropDownButton.DropDownItems[1]));
+					break;
+				case Keys.D3:
+					if (e.Control) return;
+					objGridSizeDropDownButton_DropDownItemClicked(this, new ToolStripItemClickedEventArgs(objGridSizeDropDownButton.DropDownItems[2]));
+					break;
+				case Keys.D4:
+					if (e.Control) return;
+					objGridSizeDropDownButton_DropDownItemClicked(this, new ToolStripItemClickedEventArgs(objGridSizeDropDownButton.DropDownItems[3]));
+					break;
+				case Keys.D5:
+					if (e.Control) return;
+					objGridSizeDropDownButton_DropDownItemClicked(this, new ToolStripItemClickedEventArgs(objGridSizeDropDownButton.DropDownItems[4]));
+					break;
+				case Keys.D6:
+					if (e.Control) return;
+					objGridSizeDropDownButton_DropDownItemClicked(this, new ToolStripItemClickedEventArgs(objGridSizeDropDownButton.DropDownItems[5]));
+					break;
+				case Keys.D7:
+					if (e.Control) return;
+					objGridSizeDropDownButton_DropDownItemClicked(this, new ToolStripItemClickedEventArgs(objGridSizeDropDownButton.DropDownItems[6]));
+					break;
+				case Keys.D8:
+					if (e.Control) return;
+					objGridSizeDropDownButton_DropDownItemClicked(this, new ToolStripItemClickedEventArgs(objGridSizeDropDownButton.DropDownItems[7]));
+					break;
+				case Keys.D9:
+					if (e.Control) return;
+					objGridSizeDropDownButton_DropDownItemClicked(this, new ToolStripItemClickedEventArgs(objGridSizeDropDownButton.DropDownItems[8]));
+					break;
 				case Keys.J:
 					int gs = ObjGrid + 1;
 					if (gs < objGridSizeDropDownButton.DropDownItems.Count)
@@ -2428,6 +2465,34 @@ namespace SonicRetro.SonLVL.GUI
 						DrawLevel();
 					}
 					break;
+				case Keys.C:
+					if (!loaded) return;
+					if (e.Control && !FGSelection.IsEmpty)
+						copyToolStripMenuItem1_Click(this, EventArgs.Empty);
+					break;
+				case Keys.V:
+					if (!loaded) return;
+					if (e.Control && !FGSelection.IsEmpty && Clipboard.ContainsData(typeof(LayoutSection).AssemblyQualifiedName))
+						pasteOnceToolStripMenuItem_Click(this, EventArgs.Empty);
+					break;
+				case Keys.X:
+					if (!loaded) return;
+					if (e.Control && !FGSelection.IsEmpty)
+						cutToolStripMenuItem1_Click(this, EventArgs.Empty);
+					break;
+				case Keys.H:
+					if (!loaded) return;
+					if (e.Control)
+						replaceForegroundToolStripButton_Click(this, EventArgs.Empty);
+					break;
+				case Keys.P:
+					includeobjectsWithFGToolStripMenuItem.Checked = !includeobjectsWithFGToolStripMenuItem.Checked;
+					break;
+				case Keys.Escape:
+					if (!loaded) return;
+					FGSelection = Rectangle.Empty;
+					DrawLevel();
+					break;
 			}
 			panel_KeyDown(sender, e);
 		}
@@ -2466,6 +2531,31 @@ namespace SonicRetro.SonLVL.GUI
 						SelectedChunk = (ushort)(SelectedChunk == LevelData.Chunks.Count - 1 ? 0 : SelectedChunk + 1);
 						DrawLevel();
 					}
+					break;
+				case Keys.C:
+					if (!loaded) return;
+					if (e.Control && !BGSelection.IsEmpty)
+						copyToolStripMenuItem1_Click(this, EventArgs.Empty);
+					break;
+				case Keys.V:
+					if (!loaded) return;
+					if (e.Control && !BGSelection.IsEmpty && Clipboard.ContainsData(typeof(LayoutSection).AssemblyQualifiedName))
+						pasteOnceToolStripMenuItem_Click(this, EventArgs.Empty);
+					break;
+				case Keys.X:
+					if (!loaded) return;
+					if (e.Control && !BGSelection.IsEmpty)
+						cutToolStripMenuItem1_Click(this, EventArgs.Empty);
+					break;
+				case Keys.H:
+					if (!loaded) return;
+					if (e.Control)
+						replaceBackgroundToolStripButton_Click(this, EventArgs.Empty);
+					break;
+				case Keys.Escape:
+					if (!loaded) return;
+					BGSelection = Rectangle.Empty;
+					DrawLevel();
 					break;
 			}
 			panel_KeyDown(sender, e);
@@ -3780,6 +3870,45 @@ namespace SonicRetro.SonLVL.GUI
 					else
 						return;
 					break;
+				case Keys.Q:
+					bool angles = anglesToolStripMenuItem.Checked;
+					foreach (ToolStripItem item in collisionToolStripMenuItem.DropDownItems)
+						if (item is ToolStripMenuItem)
+							((ToolStripMenuItem)item).Checked = false;
+					noneToolStripMenuItem1.Checked = true;
+					anglesToolStripMenuItem.Checked = angles;
+					DrawChunkPicture();
+					break;
+				case Keys.W:
+					angles = anglesToolStripMenuItem.Checked;
+					foreach (ToolStripItem item in collisionToolStripMenuItem.DropDownItems)
+						if (item is ToolStripMenuItem)
+							((ToolStripMenuItem)item).Checked = false;
+					path1ToolStripMenuItem.Checked = true;
+					anglesToolStripMenuItem.Checked = angles;
+					DrawChunkPicture();
+					break;
+				case Keys.E:
+					switch (LevelData.Level.ChunkFormat)
+					{
+						case EngineVersion.S1:
+						case EngineVersion.SCD:
+						case EngineVersion.SCDPC:
+							break;
+						case EngineVersion.S2:
+						case EngineVersion.S2NA:
+						case EngineVersion.S3K:
+						case EngineVersion.SKC:
+							angles = anglesToolStripMenuItem.Checked;
+							foreach (ToolStripItem item in collisionToolStripMenuItem.DropDownItems)
+								if (item is ToolStripMenuItem)
+									((ToolStripMenuItem)item).Checked = false;
+							path2ToolStripMenuItem.Checked = true;
+							anglesToolStripMenuItem.Checked = angles;
+							DrawChunkPicture();
+							break;
+					}
+					break;
 				case Keys.S:
 					foreach (ChunkBlock item in blocks)
 						if (e.Shift)
@@ -3810,6 +3939,20 @@ namespace SonicRetro.SonLVL.GUI
 					}
 					else
 						return;
+					break;
+				case Keys.C:
+					if (e.Control)
+					{
+						chunkBlockMenuMode = ChunkBlockMenuMode.Chunks;
+						copyChunkBlocksToolStripMenuItem_Click(this, EventArgs.Empty);
+					}
+					break;
+				case Keys.V:
+					if (e.Control)
+					{
+						chunkBlockMenuMode = ChunkBlockMenuMode.Chunks;
+						pasteChunkBlocksToolStripMenuItem_Click(this, EventArgs.Empty);
+					}
 					break;
 				case Keys.X:
 					foreach (ChunkBlock item in blocks)
@@ -4056,13 +4199,6 @@ namespace SonicRetro.SonLVL.GUI
 			PatternIndex[] tiles = GetSelectedBlockTiles();
 			switch (e.KeyCode)
 			{
-				case Keys.C:
-					foreach (PatternIndex item in tiles)
-						if (e.Shift)
-							item.Palette--;
-						else
-							item.Palette++;
-					break;
 				case Keys.Down:
 					if (!LevelData.Level.TwoPlayerCompatible && SelectedBlockTile.Y < 1)
 					{
@@ -4140,6 +4276,28 @@ namespace SonicRetro.SonLVL.GUI
 					}
 					else
 						return;
+					break;
+				case Keys.C:
+					if (!e.Control)
+					{
+						foreach (PatternIndex item in tiles)
+							if (e.Shift)
+								item.Palette--;
+							else
+								item.Palette++;
+					}
+					else
+					{
+						chunkBlockMenuMode = ChunkBlockMenuMode.Blocks;
+						copyChunkBlocksToolStripMenuItem_Click(this, EventArgs.Empty);
+					}
+					break;
+				case Keys.V:
+					if (e.Control)
+					{
+						chunkBlockMenuMode = ChunkBlockMenuMode.Blocks;
+						pasteChunkBlocksToolStripMenuItem_Click(this, EventArgs.Empty);
+					}
 					break;
 				case Keys.X:
 					foreach (PatternIndex item in tiles)
@@ -9409,6 +9567,23 @@ namespace SonicRetro.SonLVL.GUI
 		private void calculateAngleButton_Click(object sender, EventArgs e)
 		{
 			ColAngle.Value = LevelData.GetColMap(LevelData.ColBmps[SelectedCol])[0, 0].Angle; // super lazy
+		}
+
+		private void CollisionSelector_KeyDown(object sender, KeyEventArgs e)
+		{
+			if (!loaded) return;
+			switch (e.KeyCode)
+			{
+				case Keys.C:
+					copySolidsToolStripMenuItem_Click(this, EventArgs.Empty);
+					break;
+				case Keys.V:
+					pasteSolidsToolStripMenuItem_Click(this, EventArgs.Empty);
+					break;
+				case Keys.Delete:
+					clearSolidsToolStripMenuItem_Click(this, EventArgs.Empty);
+					break;
+			}
 		}
 
 		private void CollisionSelector_MouseDown(object sender, MouseEventArgs e)

--- a/SonLVL/MainForm.cs
+++ b/SonLVL/MainForm.cs
@@ -2102,8 +2102,17 @@ namespace SonicRetro.SonLVL.GUI
 			{
 				case Keys.Y:
 					if (!loaded) return;
-					if (e.Control && RedoList.Count > 0)
-						DoRedo(1);
+					if (e.Control)
+					{
+						if (RedoList.Count > 0)
+							DoRedo(1);
+					}
+					else
+					{
+						lowToolStripMenuItem.Checked = !lowToolStripMenuItem.Checked;
+						DrawLevel();
+						DrawChunkPicture();
+					}
 					break;
 				case Keys.Z:
 					if (!loaded) return;
@@ -2153,6 +2162,56 @@ namespace SonicRetro.SonLVL.GUI
 				case Keys.NumPad4:
 					if (e.Control)
 						CurrentTab = Tab.Art;
+					break;
+				case Keys.Q:
+					if (!loaded) return;
+					bool angles = anglesToolStripMenuItem.Checked;
+					foreach (ToolStripItem item in collisionToolStripMenuItem.DropDownItems)
+						if (item is ToolStripMenuItem)
+							((ToolStripMenuItem)item).Checked = false;
+					noneToolStripMenuItem1.Checked = true;
+					anglesToolStripMenuItem.Checked = angles;
+					DrawLevel();
+					DrawChunkPicture();
+					break;
+				case Keys.W:
+					if (!loaded) return;
+					angles = anglesToolStripMenuItem.Checked;
+					foreach (ToolStripItem item in collisionToolStripMenuItem.DropDownItems)
+						if (item is ToolStripMenuItem)
+							((ToolStripMenuItem)item).Checked = false;
+					path1ToolStripMenuItem.Checked = true;
+					anglesToolStripMenuItem.Checked = angles;
+					DrawLevel();
+					DrawChunkPicture();
+					break;
+				case Keys.E:
+					if (!loaded) return;
+					switch (LevelData.Level.ChunkFormat)
+					{
+						case EngineVersion.S1:
+						case EngineVersion.SCD:
+						case EngineVersion.SCDPC:
+							break;
+						case EngineVersion.S2:
+						case EngineVersion.S2NA:
+						case EngineVersion.S3K:
+						case EngineVersion.SKC:
+							angles = anglesToolStripMenuItem.Checked;
+							foreach (ToolStripItem item in collisionToolStripMenuItem.DropDownItems)
+								if (item is ToolStripMenuItem)
+									((ToolStripMenuItem)item).Checked = false;
+							path2ToolStripMenuItem.Checked = true;
+							anglesToolStripMenuItem.Checked = angles;
+							DrawLevel();
+							DrawChunkPicture();
+							break;
+					}
+					break;
+				case Keys.U:
+					highToolStripMenuItem.Checked = !highToolStripMenuItem.Checked;
+					DrawLevel();
+					DrawChunkPicture();
 					break;
 			}
 		}
@@ -2582,45 +2641,6 @@ namespace SonicRetro.SonLVL.GUI
 		{
 			switch (e.KeyCode)
 			{
-				case Keys.Q:
-					bool angles = anglesToolStripMenuItem.Checked;
-					foreach (ToolStripItem item in collisionToolStripMenuItem.DropDownItems)
-						if (item is ToolStripMenuItem)
-							((ToolStripMenuItem)item).Checked = false;
-					noneToolStripMenuItem1.Checked = true;
-					anglesToolStripMenuItem.Checked = angles;
-					DrawLevel();
-					break;
-				case Keys.W:
-					angles = anglesToolStripMenuItem.Checked;
-					foreach (ToolStripItem item in collisionToolStripMenuItem.DropDownItems)
-						if (item is ToolStripMenuItem)
-							((ToolStripMenuItem)item).Checked = false;
-					path1ToolStripMenuItem.Checked = true;
-					anglesToolStripMenuItem.Checked = angles;
-					DrawLevel();
-					break;
-				case Keys.E:
-					switch (LevelData.Level.ChunkFormat)
-					{
-						case EngineVersion.S1:
-						case EngineVersion.SCD:
-						case EngineVersion.SCDPC:
-							break;
-						case EngineVersion.S2:
-						case EngineVersion.S2NA:
-						case EngineVersion.S3K:
-						case EngineVersion.SKC:
-							angles = anglesToolStripMenuItem.Checked;
-							foreach (ToolStripItem item in collisionToolStripMenuItem.DropDownItems)
-								if (item is ToolStripMenuItem)
-									((ToolStripMenuItem)item).Checked = false;
-							path2ToolStripMenuItem.Checked = true;
-							anglesToolStripMenuItem.Checked = angles;
-							DrawLevel();
-							break;
-					}
-					break;
 				case Keys.R:
 					if (!(e.Alt & e.Control))
 					{
@@ -2630,17 +2650,6 @@ namespace SonicRetro.SonLVL.GUI
 					break;
 				case Keys.T:
 					objectsAboveHighPlaneToolStripMenuItem.Checked = !objectsAboveHighPlaneToolStripMenuItem.Checked;
-					DrawLevel();
-					break;
-				case Keys.Y:
-					if (!e.Control)
-					{
-						lowToolStripMenuItem.Checked = !lowToolStripMenuItem.Checked;
-						DrawLevel();
-					}
-					break;
-				case Keys.U:
-					highToolStripMenuItem.Checked = !highToolStripMenuItem.Checked;
 					DrawLevel();
 					break;
 				case Keys.I:
@@ -3886,45 +3895,6 @@ namespace SonicRetro.SonLVL.GUI
 					}
 					else
 						return;
-					break;
-				case Keys.Q:
-					bool angles = anglesToolStripMenuItem.Checked;
-					foreach (ToolStripItem item in collisionToolStripMenuItem.DropDownItems)
-						if (item is ToolStripMenuItem)
-							((ToolStripMenuItem)item).Checked = false;
-					noneToolStripMenuItem1.Checked = true;
-					anglesToolStripMenuItem.Checked = angles;
-					DrawChunkPicture();
-					break;
-				case Keys.W:
-					angles = anglesToolStripMenuItem.Checked;
-					foreach (ToolStripItem item in collisionToolStripMenuItem.DropDownItems)
-						if (item is ToolStripMenuItem)
-							((ToolStripMenuItem)item).Checked = false;
-					path1ToolStripMenuItem.Checked = true;
-					anglesToolStripMenuItem.Checked = angles;
-					DrawChunkPicture();
-					break;
-				case Keys.E:
-					switch (LevelData.Level.ChunkFormat)
-					{
-						case EngineVersion.S1:
-						case EngineVersion.SCD:
-						case EngineVersion.SCDPC:
-							break;
-						case EngineVersion.S2:
-						case EngineVersion.S2NA:
-						case EngineVersion.S3K:
-						case EngineVersion.SKC:
-							angles = anglesToolStripMenuItem.Checked;
-							foreach (ToolStripItem item in collisionToolStripMenuItem.DropDownItems)
-								if (item is ToolStripMenuItem)
-									((ToolStripMenuItem)item).Checked = false;
-							path2ToolStripMenuItem.Checked = true;
-							anglesToolStripMenuItem.Checked = angles;
-							DrawChunkPicture();
-							break;
-					}
 					break;
 				case Keys.S:
 					foreach (ChunkBlock item in blocks)

--- a/SonLVL/MainForm.cs
+++ b/SonLVL/MainForm.cs
@@ -871,6 +871,21 @@ namespace SonicRetro.SonLVL.GUI
 			Enabled = true;
 			UseWaitCursor = false;
 			DrawLevel();
+
+			switch (CurrentTab)
+			{
+				case Tab.Objects:
+					objectPanel.Focus();
+					break;
+
+				case Tab.Foreground:
+					foregroundPanel.Focus();
+					break;
+
+				case Tab.Background:
+					backgroundPanel.Focus();
+					break;
+			}
 		}
 
 		private void RefreshTileSelector()

--- a/SonLVL/MainForm.cs
+++ b/SonLVL/MainForm.cs
@@ -87,7 +87,7 @@ namespace SonicRetro.SonLVL.GUI
 		{
 			Log(e.Exception.ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.None));
 			File.WriteAllLines("SonLVL.log", LogFile.ToArray());
-			using (ErrorDialog ed = new ErrorDialog("Unhandled Exception " + e.Exception.GetType().Name + "\nLog file has been saved.\n\nDo you want to try to continue running?", true))
+			using (ErrorDialog ed = new ErrorDialog("Unhandled Exception " + e.Exception.GetType().Name + "\nLog file has been saved.\n\nDo you want to try to continue running?", Enabled))
 			{
 				if (ed.ShowDialog(this) == DialogResult.Cancel)
 					Close();

--- a/SonLVL/MainForm.cs
+++ b/SonLVL/MainForm.cs
@@ -85,6 +85,7 @@ namespace SonicRetro.SonLVL.GUI
 
 		void Application_ThreadException(object sender, System.Threading.ThreadExceptionEventArgs e)
 		{
+			UseWaitCursor = false;
 			Log(e.Exception.ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.None));
 			File.WriteAllLines("SonLVL.log", LogFile.ToArray());
 			using (ErrorDialog ed = new ErrorDialog("Unhandled Exception " + e.Exception.GetType().Name + "\nLog file has been saved.\n\nDo you want to try to continue running?", Enabled))

--- a/SonLVL/MainForm.cs
+++ b/SonLVL/MainForm.cs
@@ -9716,6 +9716,8 @@ namespace SonicRetro.SonLVL.GUI
 			Array.Clear(LevelData.ColArr1[CollisionSelector.SelectedIndex], 0, 16);
 			LevelData.Angles[CollisionSelector.SelectedIndex] = 0;
 			LevelData.RedrawCol(CollisionSelector.SelectedIndex, true);
+			CollisionSelector.Images[SelectedCol] = LevelData.ColBmps[SelectedCol];
+			CollisionSelector.Invalidate();
 			CollisionSelector_SelectedIndexChanged(this, EventArgs.Empty);
 		}
 

--- a/SonLVL/MainForm.cs
+++ b/SonLVL/MainForm.cs
@@ -6312,7 +6312,7 @@ namespace SonicRetro.SonLVL.GUI
 				xflip = LevelData.Layout.BGXFlip;
 				yflip = LevelData.Layout.BGYFlip;
 				selection = BGSelection;
-				area = new Rectangle(BGSelection.X * 128, BGSelection.Y * 128, BGSelection.Width * 128, BGSelection.Height * 128);
+				area = BGSelection.Scale(LevelData.Level.ChunkWidth, LevelData.Level.ChunkHeight);
 				data.SetImage(LevelData.DrawBackground(area, lowToolStripMenuItem.Checked, highToolStripMenuItem.Checked, path1ToolStripMenuItem.Checked, path2ToolStripMenuItem.Checked).ToBitmap(LevelImgPalette));
 			}
 			else
@@ -6321,7 +6321,8 @@ namespace SonicRetro.SonLVL.GUI
 				loop = LevelData.Layout.FGLoop;
 				xflip = LevelData.Layout.FGXFlip;
 				yflip = LevelData.Layout.FGYFlip;
-				selection = FGSelection; area = new Rectangle(FGSelection.X * 128, FGSelection.Y * 128, FGSelection.Width * 128, FGSelection.Height * 128);
+				selection = FGSelection;
+				area = FGSelection.Scale(LevelData.Level.ChunkWidth, LevelData.Level.ChunkHeight);
 				data.SetImage(LevelData.DrawForeground(area, includeobjectsWithFGToolStripMenuItem.Checked, !hideDebugObjectsToolStripMenuItem.Checked, objectsAboveHighPlaneToolStripMenuItem.Checked, lowToolStripMenuItem.Checked, highToolStripMenuItem.Checked, path1ToolStripMenuItem.Checked, path2ToolStripMenuItem.Checked, allToolStripMenuItem.Checked).ToBitmap(LevelImgPalette));
 			}
 
@@ -6417,12 +6418,12 @@ namespace SonicRetro.SonLVL.GUI
 			Rectangle area;
 			if (CurrentTab == Tab.Background)
 			{
-				area = new Rectangle(BGSelection.X * 128, BGSelection.Y * 128, BGSelection.Width * 128, BGSelection.Height * 128);
+				area = BGSelection.Scale(LevelData.Level.ChunkWidth, LevelData.Level.ChunkHeight);
 				data.SetImage(LevelData.DrawBackground(area, lowToolStripMenuItem.Checked, highToolStripMenuItem.Checked, path1ToolStripMenuItem.Checked, path2ToolStripMenuItem.Checked).ToBitmap(LevelImgPalette));
 			}
 			else
 			{
-				area = new Rectangle(FGSelection.X * 128, FGSelection.Y * 128, FGSelection.Width * 128, FGSelection.Height * 128);
+				area = FGSelection.Scale(LevelData.Level.ChunkWidth, LevelData.Level.ChunkHeight);
 				data.SetImage(LevelData.DrawForeground(area, includeobjectsWithFGToolStripMenuItem.Checked, !hideDebugObjectsToolStripMenuItem.Checked, objectsAboveHighPlaneToolStripMenuItem.Checked, lowToolStripMenuItem.Checked, highToolStripMenuItem.Checked, path1ToolStripMenuItem.Checked, path2ToolStripMenuItem.Checked, allToolStripMenuItem.Checked).ToBitmap(LevelImgPalette));
 			}
 

--- a/SonLVL/MainForm.cs
+++ b/SonLVL/MainForm.cs
@@ -10271,11 +10271,13 @@ namespace SonicRetro.SonLVL.GUI
 					switch (CurrentTab)
 					{
 						case Tab.Foreground:
+							Rectangle area = FGSelection.Scale(LevelData.Level.ChunkWidth, LevelData.Level.ChunkHeight);
+							
 							if (exportArtcollisionpriorityToolStripMenuItem.Checked)
 							{
 								string pathBase = Path.Combine(Path.GetDirectoryName(a.FileName), Path.GetFileNameWithoutExtension(a.FileName));
 								string pathExt = Path.GetExtension(a.FileName);
-								BitmapBits bmp = LevelData.DrawForeground(FGSelection, false, false, false, true, true, false, false, false);
+								BitmapBits bmp = LevelData.DrawForeground(area, false, false, false, true, true, false, false, false);
 								for (int i = 0; i < bmp.Bits.Length; i++)
 									if (bmp.Bits[i] == 0)
 										bmp.Bits[i] = 32;
@@ -10307,16 +10309,16 @@ namespace SonicRetro.SonLVL.GUI
 								}
 								if (dualPath)
 								{
-									bmp = LevelData.DrawForeground(FGSelection, false, false, false, false, false, true, false, false);
+									bmp = LevelData.DrawForeground(area, false, false, false, false, false, true, false, false);
 									bmp.UnfixUIColors();
 									bmp.ToBitmap4bpp(Color.Magenta, Color.White, Color.Yellow, Color.Black).Save(pathBase + "_col1" + pathExt);
-									bmp = LevelData.DrawForeground(FGSelection, false, false, false, false, false, false, true, false);
+									bmp = LevelData.DrawForeground(area, false, false, false, false, false, false, true, false);
 									bmp.UnfixUIColors();
 									bmp.ToBitmap4bpp(Color.Magenta, Color.White, Color.Yellow, Color.Black).Save(pathBase + "_col2" + pathExt);
 								}
 								else if (LevelData.LayoutFormat.HasLoopFlag && LevelData.Layout.FGLoop.OfType<bool>().Any(b => b))
 								{
-									bmp = LevelData.DrawForeground(FGSelection, false, false, false, false, false, true, false, false);
+									bmp = LevelData.DrawForeground(area, false, false, false, false, false, true, false, false);
 									bmp.UnfixUIColors();
 									bmp.ToBitmap4bpp(Color.Magenta, Color.White, Color.Yellow, Color.Black).Save(pathBase + "_col1" + pathExt);
 									ushort[,] copy = (ushort[,])LevelData.Layout.FGLayout.Clone();
@@ -10324,14 +10326,14 @@ namespace SonicRetro.SonLVL.GUI
 										for (int x = FGSelection.Left; x < FGSelection.Right; x++)
 											if (LevelData.Layout.FGLoop[x, y])
 												LevelData.Layout.FGLayout[x, y]++;
-									bmp = LevelData.DrawForeground(FGSelection, false, false, false, false, false, true, false, false);
+									bmp = LevelData.DrawForeground(area, false, false, false, false, false, true, false, false);
 									bmp.UnfixUIColors();
 									bmp.ToBitmap4bpp(Color.Magenta, Color.White, Color.Yellow, Color.Black).Save(pathBase + "_col2" + pathExt);
 									LevelData.Layout.FGLayout = copy;
 								}
 								else
 								{
-									bmp = LevelData.DrawForeground(FGSelection, false, false, false, false, false, true, false, false);
+									bmp = LevelData.DrawForeground(area, false, false, false, false, false, true, false, false);
 									bmp.UnfixUIColors();
 									bmp.ToBitmap4bpp(Color.Magenta, Color.White, Color.Yellow, Color.Black).Save(pathBase + "_col" + pathExt);
 								}
@@ -10358,7 +10360,7 @@ namespace SonicRetro.SonLVL.GUI
 							}
 							else
 							{
-								BitmapBits bmp = LevelData.DrawForeground(FGSelection, includeobjectsWithFGToolStripMenuItem.Checked, !hideDebugObjectsToolStripMenuItem.Checked, objectsAboveHighPlaneToolStripMenuItem.Checked, lowToolStripMenuItem.Checked, highToolStripMenuItem.Checked, path1ToolStripMenuItem.Checked, path2ToolStripMenuItem.Checked, allToolStripMenuItem.Checked);
+								BitmapBits bmp = LevelData.DrawForeground(area, includeobjectsWithFGToolStripMenuItem.Checked, !hideDebugObjectsToolStripMenuItem.Checked, objectsAboveHighPlaneToolStripMenuItem.Checked, lowToolStripMenuItem.Checked, highToolStripMenuItem.Checked, path1ToolStripMenuItem.Checked, path2ToolStripMenuItem.Checked, allToolStripMenuItem.Checked);
 								int w = LevelData.WaterHeight - (FGSelection.Top * LevelData.Level.ChunkHeight);
 								if (LevelData.WaterPalette != -1 && bmp.Height > w)
 									bmp.ApplyWaterPalette(w);
@@ -10367,11 +10369,13 @@ namespace SonicRetro.SonLVL.GUI
 							}
 							break;
 						case Tab.Background:
+							area = BGSelection.Scale(LevelData.Level.ChunkWidth, LevelData.Level.ChunkHeight);
+
 							if (exportArtcollisionpriorityToolStripMenuItem.Checked)
 							{
 								string pathBase = Path.Combine(Path.GetDirectoryName(a.FileName), Path.GetFileNameWithoutExtension(a.FileName));
 								string pathExt = Path.GetExtension(a.FileName);
-								BitmapBits bmp = LevelData.DrawBackground(BGSelection, true, true, false, false);
+								BitmapBits bmp = LevelData.DrawBackground(area, true, true, false, false);
 								for (int i = 0; i < bmp.Bits.Length; i++)
 									if (bmp.Bits[i] == 0)
 										bmp.Bits[i] = 32;
@@ -10394,16 +10398,16 @@ namespace SonicRetro.SonLVL.GUI
 								}
 								if (dualPath)
 								{
-									bmp = LevelData.DrawBackground(BGSelection, false, false, true, false);
+									bmp = LevelData.DrawBackground(area, false, false, true, false);
 									bmp.UnfixUIColors();
 									bmp.ToBitmap4bpp(Color.Magenta, Color.White, Color.Yellow, Color.Black).Save(pathBase + "_col1" + pathExt);
-									bmp = LevelData.DrawBackground(BGSelection, false, false, false, true);
+									bmp = LevelData.DrawBackground(area, false, false, false, true);
 									bmp.UnfixUIColors();
 									bmp.ToBitmap4bpp(Color.Magenta, Color.White, Color.Yellow, Color.Black).Save(pathBase + "_col2" + pathExt);
 								}
 								else if (LevelData.LayoutFormat.HasLoopFlag && LevelData.Layout.BGLoop.OfType<bool>().Any(b => b))
 								{
-									bmp = LevelData.DrawBackground(BGSelection, false, false, true, false);
+									bmp = LevelData.DrawBackground(area, false, false, true, false);
 									bmp.UnfixUIColors();
 									bmp.ToBitmap4bpp(Color.Magenta, Color.White, Color.Yellow, Color.Black).Save(pathBase + "_col1" + pathExt);
 									ushort[,] copy = (ushort[,])LevelData.Layout.BGLayout.Clone();
@@ -10411,14 +10415,14 @@ namespace SonicRetro.SonLVL.GUI
 										for (int x = BGSelection.Left; x < BGSelection.Right; x++)
 											if (LevelData.Layout.BGLoop[x, y])
 												LevelData.Layout.BGLayout[x, y]++;
-									bmp = LevelData.DrawBackground(BGSelection, false, false, true, false);
+									bmp = LevelData.DrawBackground(area, false, false, true, false);
 									bmp.UnfixUIColors();
 									bmp.ToBitmap4bpp(Color.Magenta, Color.White, Color.Yellow, Color.Black).Save(pathBase + "_col2" + pathExt);
 									LevelData.Layout.BGLayout = copy;
 								}
 								else
 								{
-									bmp = LevelData.DrawBackground(BGSelection, false, false, true, false);
+									bmp = LevelData.DrawBackground(area, false, false, true, false);
 									bmp.UnfixUIColors();
 									bmp.ToBitmap4bpp(Color.Magenta, Color.White, Color.Yellow, Color.Black).Save(pathBase + "_col" + pathExt);
 								}
@@ -10445,7 +10449,7 @@ namespace SonicRetro.SonLVL.GUI
 							}
 							else
 							{
-								BitmapBits bmp = LevelData.DrawBackground(BGSelection, lowToolStripMenuItem.Checked, highToolStripMenuItem.Checked, path1ToolStripMenuItem.Checked, path2ToolStripMenuItem.Checked);
+								BitmapBits bmp = LevelData.DrawBackground(area, lowToolStripMenuItem.Checked, highToolStripMenuItem.Checked, path1ToolStripMenuItem.Checked, path2ToolStripMenuItem.Checked);
 								using (Bitmap res = bmp.ToBitmap(LevelImgPalette))
 									res.Save(a.FileName);
 							}

--- a/SonLVLAPI/TileList.cs
+++ b/SonLVLAPI/TileList.cs
@@ -91,14 +91,16 @@ namespace SonicRetro.SonLVL.API
 			switch (Direction)
 			{
 				case Direction.Horizontal:
-					int tilesPerCol = Math.Max((Height - hScrollBar1.Height) / (imageHeight + 4), 1);
-					hScrollBar1.Maximum = Math.Max(((int)Math.Ceiling(Images.Count / (double)tilesPerCol) * (imageWidth + 4)) - Width, 0);
 					hScrollBar1.SmallChange = hScrollBar1.LargeChange = imageHeight + 4;
+					int tilesPerCol = Math.Max((Height - hScrollBar1.Height) / (imageHeight + 4), 1);
+					int columnCount = (int)Math.Ceiling(Images.Count / (double)tilesPerCol);
+					hScrollBar1.Maximum = Math.Max((columnCount * (imageWidth + 4)) - Width, 0) + hScrollBar1.LargeChange - 1;
 					break;
 				case Direction.Vertical:
-					int tilesPerRow = Math.Max((Width - vScrollBar1.Width) / (imageWidth + 4), 1);
-					vScrollBar1.Maximum = Math.Max(((int)Math.Ceiling(Images.Count / (double)tilesPerRow) * (imageHeight + 4)) - Height, 0);
 					vScrollBar1.SmallChange = vScrollBar1.LargeChange = imageWidth + 4;
+					int tilesPerRow = Math.Max((Width - vScrollBar1.Width) / (imageWidth + 4), 1);
+					int rowCount = (int)Math.Ceiling(Images.Count / (double)tilesPerRow);
+					vScrollBar1.Maximum = Math.Max((rowCount * (imageHeight + 4)) - Height, 0) + vScrollBar1.LargeChange - 1;
 					break;
 			}
 			Invalidate();
@@ -327,9 +329,9 @@ namespace SonicRetro.SonLVL.API
 			set
 			{
 				if (direction == API.Direction.Horizontal)
-					hScrollBar1.Value = Math.Min(hScrollBar1.Maximum, Math.Max(0, value));
+					hScrollBar1.Value = Math.Min(hScrollBar1.Maximum - hScrollBar1.LargeChange + 1, Math.Max(0, value));
 				else
-					vScrollBar1.Value = Math.Min(vScrollBar1.Maximum, Math.Max(0, value));
+					vScrollBar1.Value = Math.Min(vScrollBar1.Maximum - vScrollBar1.LargeChange + 1, Math.Max(0, value));
 			}
 		}
 

--- a/SonLVLAPI/TileList.cs
+++ b/SonLVLAPI/TileList.cs
@@ -350,7 +350,11 @@ namespace SonicRetro.SonLVL.API
 						hScrollBar1.Value += x;
 					if (x + actualImageWidth > Width)
 						hScrollBar1.Value += (x + actualImageWidth) - Width;
+
+					// Pardon the odd synatx.. but let's make sure to clamp the value within bounds
+					ScrollValue = hScrollBar1.Value;
 					break;
+
 				case Direction.Vertical:
 					int tilesPerRow = Math.Max((Width - vScrollBar1.Width) / actualImageWidth, 1);
 					int y = ((SelectedIndex / tilesPerRow) * actualImageHeight) - vScrollBar1.Value;
@@ -358,6 +362,9 @@ namespace SonicRetro.SonLVL.API
 						vScrollBar1.Value += y;
 					if (y + actualImageHeight > Height)
 						vScrollBar1.Value += (y + actualImageHeight) - Height;
+
+					// Pardon the odd synatx.. but let's make sure to clamp the value within bounds
+					ScrollValue = vScrollBar1.Value;
 					break;
 			}
 		}

--- a/SonPLN/MainForm.Designer.cs
+++ b/SonPLN/MainForm.Designer.cs
@@ -616,6 +616,7 @@ namespace SonicRetro.SonLVL.SonPLN
             this.enableGridToolStripMenuItem.ShortcutKeyDisplayString = "I";
             this.enableGridToolStripMenuItem.Size = new System.Drawing.Size(119, 22);
             this.enableGridToolStripMenuItem.Text = "&Enable";
+            this.enableGridToolStripMenuItem.Click += new System.EventHandler(this.enableGridToolStripMenuItem_Click);
             // 
             // gridColorToolStripMenuItem
             // 

--- a/SonPLN/MainForm.cs
+++ b/SonPLN/MainForm.cs
@@ -726,6 +726,12 @@ namespace SonicRetro.SonLVL.SonPLN
 			a.Dispose();
 		}
 
+		private void enableGridToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			if (loaded)
+				DrawLevel();
+		}
+
 		private void zoomToolStripMenuItem_DropDownItemClicked(object sender, ToolStripItemClickedEventArgs e)
 		{
 			foreach (ToolStripMenuItem item in zoomToolStripMenuItem.DropDownItems)
@@ -1086,7 +1092,10 @@ namespace SonicRetro.SonLVL.SonPLN
 					if (e.Control)
 						cutToolStripMenuItem1_Click(this, EventArgs.Empty);
 					else
+					{
 						xFlip.Checked = !xFlip.Checked;
+						DrawLevel();
+					}
 					break;
 				case Keys.V:
 					if (!loaded || !e.Control || FGSelection.IsEmpty) return;
@@ -1096,10 +1105,12 @@ namespace SonicRetro.SonLVL.SonPLN
 				case Keys.S:
 					if (!loaded || e.Control) return;
 					yFlip.Checked = !yFlip.Checked;
+					DrawLevel();
 					break;
 				case Keys.P:
 					if (!loaded || e.Control) return;
 					priority.Checked = !priority.Checked;
+					DrawLevel();
 					break;
 				case Keys.A:
 					if (!loaded) return;

--- a/SonPLN/MainForm.cs
+++ b/SonPLN/MainForm.cs
@@ -2174,11 +2174,22 @@ namespace SonicRetro.SonLVL.SonPLN
 				Point clientPoint = TileSelector.PointToClient(new Point(e.X, e.Y));
 				ushort newindex = (ushort)TileSelector.GetItemAtPoint(clientPoint);
 				ushort oldindex = (ushort)(int)e.Data.GetData("SonPLNTileIndex_" + pid);
-				if (newindex == oldindex) return;
+				
+				if (newindex == oldindex)
+				{
+					TileSelector.Invalidate();
+					return;
+				}
+
 				if ((ModifierKeys & Keys.Control) == Keys.Control)
 				{
-					if (newindex == TileSelector.Images.Count) return;
-						LevelData.Tiles.Swap(oldindex, newindex);
+					if (newindex == TileSelector.Images.Count)
+					{
+						TileSelector.Invalidate();
+						return;
+					}
+
+					LevelData.Tiles.Swap(oldindex, newindex);
 					TileSelector.Images.Swap(oldindex, newindex);
 					LevelData.UpdateTileArray();
 					for (int y = 0; y < planemap.GetLength(1); y++)
@@ -2193,8 +2204,13 @@ namespace SonicRetro.SonLVL.SonPLN
 				}
 				else
 				{
-					if (newindex == oldindex + 1) return;
-						LevelData.Tiles.Move(oldindex, newindex);
+					if (newindex == oldindex + 1)
+					{
+						TileSelector.Invalidate();
+						return;
+					}
+
+					LevelData.Tiles.Move(oldindex, newindex);
 					TileSelector.Images.Move(oldindex, newindex);
 					LevelData.UpdateTileArray();
 					for (int y = 0; y < planemap.GetLength(1); y++)
@@ -2270,6 +2286,7 @@ namespace SonicRetro.SonLVL.SonPLN
 			LevelData.Tiles[SelectedTile] = t;
 			t.CopyTo(LevelData.TileArray, SelectedTile * 32);
 			TileSelector.Images[SelectedTile] = LevelData.TileToBmp4bpp(LevelData.Tiles[SelectedTile], 0, SelectedColor.Y, false);
+			TileSelector.Invalidate();
 		}
 
 		private void importToolStripMenuItem2_Click(object sender, EventArgs e)

--- a/SonPLN/MainForm.cs
+++ b/SonPLN/MainForm.cs
@@ -560,6 +560,11 @@ namespace SonicRetro.SonLVL.SonPLN
 			Enabled = true;
 			UseWaitCursor = false;
 			DrawLevel();
+
+			if (CurrentTab == Tab.Foreground)
+				foregroundPanel.Focus();
+			else
+				TileSelector.Focus();
 		}
 
 		private void RefreshTileSelector()


### PR DESCRIPTION
This Pull Request primarily carries over the copying enhancements from #204 into SonLVL itself. This is applied to:
- A segment of the level, from both the Foreground and the Background
- A single chunk
- Several blocks from within a chunk (in the chunk editor)
- A single block
- Several tiles from within a block (in the block editor)
- A single tile
- Or, a collision mask

Whenever copying any of the above, not only is the binary data copied, but so is an image render of the data as well. This image render can then be pasted into anything that accepts images, such as an image editing software for the user to further edit the art in, or into Discord to share the section of the level they created.

Beyond that, a handful of keyboard shortcuts have been added across the editor:
- The collision shortcut keys (Q/W/E, but not R), as well as the layer keys (Y/U), have been made global, as they affect all tabs in the editor.
- Objects tab:
  - Number row keys: Set grid size (as opposed to increasing/decreasing it with the J/M keys)
  - The 1 and 0 keys set the grid size to 1, given their locations on opposite sides of the number row, while the 1-8 keys set the grid size in ascending values.
- Foreground/Background tabs:
  - CTRL+C: Copy selected area
  - CTRL+X: Cut selected area
  - CTRL+V: Paste once into selected area
  - CTRL+H: Replace chunks
  - Escape: Cancel current selection
  - P: Toggle objects visibility (Foreground tab only)
- Chunk Editor:
  - CTRL+C: Copy the currently selected chunk blocks
  - CTRL+V: Paste the currently copied chunk blocks
- Block Editor:
  - CTRL+C: Copy the currently selected block tiles
  - CTRL+V: Paste the currently copied block tiles
- Solids List:
  - CTRL+C/CTRL+V: Copy/paste, hopefully fairly self explanatory by this point
  - Delete key: Deletes the currently selected solid.

Additionally, some minor bugfixes and tweaks are also included:
- Fix Tile List scrolling limits
  - Previously, the tile list's scrollbar would only let the user see up until the *second* to last row/column of tiles, instead of letting the user actually see *all* of the tiles.
  - This change affects all projects that utilise the control, from SonLVL to SonPLN to SonAni.
- Whenever the editor encounters a critical error while loading a level, don't allow the user to press the "Continue" button on the error message form (as doing so would make SonLVL impossible to close without using Task Manager). Additionally, disable the Wait Cursor instead of retaining it indefinitely.
- When loading a new level, reset the user's selection.
  - Previously, the user would be able to bring selections across levels. This could allow having a selection that's larger than the currently level itself, which would lead to a crash.
- When using Advanced Remapping in the Art Tab, create deep copies instead of reference copies.
  - Previously, only shallow copies were created, so if a user copied chunk A over chunk B without replacing chunk A, then chunk A and chunk B would still be tied to the same reference internally, so attempting to edit one would also seemingly edit the other.
- When filling a layout area in the FG/BG tabs, respect the currently selected X/Y flip settings instead of defaulting to false.
- When pasting once in the FG/BG tabs, paste at the top left of the highlighted area, and select the entire pasted area afterwards.
- Fix exporting layout sections (previously the dimensions of the image would be the chunk dimensions instead of the actual pixel count, ie exporting a section of 2x1 chunks in S2 would export a 2x1px image, instead of a 256x128px image)
- Redraw the tile (block/chunk) lists in more scenarios when needed:
  - Whenever dragging and dropping a tile onto the same spot, the drag-and-drop preview of the tile would previously continue to stay visible even after releasing the mouse.
  - Similarly, after Pasting Over a tile, the list would not redraw, so it would appear as if the paste operation had no effect until the user clicked onto another tile.
  - When clearing a solid in particular, make sure to redraw the list afterwards.
  - These changes apply to both SonPLN as well as SonLVL.
- Upon loading into a level, bring the user's focus onto the current tab they're in.
- SonPLN: Redraw the mapping after toggling grid visibility/using keyboard shortcuts.