### PR TITLE
Fix SonLVLAPI build

### DIFF
--- a/SonLVLAPI/SonLVL.API.csproj
+++ b/SonLVLAPI/SonLVL.API.csproj
@@ -126,7 +126,6 @@
     <Compile Include="S1\Object.cs" />
     <Compile Include="S1\Ring.cs" />
     <Compile Include="S2NA\Layout.cs" />
-    <Compile Include="S2NA\Object.cs" />
     <Compile Include="S2\Layout.cs" />
     <Compile Include="S2\Object.cs" />
     <Compile Include="S2\Ring.cs" />


### PR DESCRIPTION
Fixes the SonLVLAPI project file still containing a reference to `S2NA/Object.cs`, which was removed in #218.

Apologies, among the rest of my working/in-progress changes, I completely forgot to commit this file with the previous pull request. Once again, I apologise.