### PR TITLE
SonLVL: Add Background Colour setting

### DIFF
--- a/SonLVL/BackgroundColorDialog.Designer.cs
+++ b/SonLVL/BackgroundColorDialog.Designer.cs
@@ -1,0 +1,208 @@
+﻿namespace SonicRetro.SonLVL
+{
+	partial class BackgroundColorDialog
+	{
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Windows Form Designer generated code
+
+		/// <summary>
+		/// Required method for Designer support - do not modify
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent()
+		{
+            this.useLevelColor = new System.Windows.Forms.RadioButton();
+            this.useCustomColor = new System.Windows.Forms.RadioButton();
+            this.palettePanel = new System.Windows.Forms.Panel();
+            this.indexLabel = new System.Windows.Forms.Label();
+            this.index = new System.Windows.Forms.NumericUpDown();
+            this.okButton = new System.Windows.Forms.Button();
+            this.cancelButton = new System.Windows.Forms.Button();
+            this.customColorBox = new System.Windows.Forms.PictureBox();
+            this.colorChange = new System.Windows.Forms.Button();
+            this.label1 = new System.Windows.Forms.Label();
+            this.customColorOverlay = new System.Windows.Forms.PictureBox();
+            ((System.ComponentModel.ISupportInitialize)(this.index)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.customColorBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.customColorOverlay)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // useLevelColor
+            // 
+            this.useLevelColor.AutoSize = true;
+            this.useLevelColor.Location = new System.Drawing.Point(29, 30);
+            this.useLevelColor.Name = "useLevelColor";
+            this.useLevelColor.Size = new System.Drawing.Size(214, 29);
+            this.useLevelColor.TabIndex = 3;
+            this.useLevelColor.Text = "Use Level Color...";
+            this.useLevelColor.UseVisualStyleBackColor = true;
+            this.useLevelColor.CheckedChanged += new System.EventHandler(this.useLevelColor_CheckedChanged);
+			// 
+			// useCustomColor
+			// 
+			this.useCustomColor.AutoSize = true;
+            this.useCustomColor.Location = new System.Drawing.Point(29, 242);
+            this.useCustomColor.Name = "useCustomColor";
+            this.useCustomColor.Size = new System.Drawing.Size(248, 29);
+            this.useCustomColor.TabIndex = 4;
+            this.useCustomColor.Text = "Use Custom Color...";
+            this.useCustomColor.UseVisualStyleBackColor = true;
+            this.useCustomColor.CheckedChanged += new System.EventHandler(this.useCustomColor_CheckedChanged);
+            // 
+            // palettePanel
+            // 
+            this.palettePanel.Location = new System.Drawing.Point(29, 86);
+            this.palettePanel.Name = "palettePanel";
+            this.palettePanel.Size = new System.Drawing.Size(512, 123);
+            this.palettePanel.TabIndex = 5;
+            this.palettePanel.Paint += new System.Windows.Forms.PaintEventHandler(this.palettePanel_Paint);
+            this.palettePanel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.palettePanel_MouseDown);
+            // 
+            // indexLabel
+            // 
+            this.indexLabel.AutoSize = true;
+            this.indexLabel.Location = new System.Drawing.Point(323, 30);
+            this.indexLabel.Name = "indexLabel";
+            this.indexLabel.Size = new System.Drawing.Size(76, 25);
+            this.indexLabel.TabIndex = 6;
+            this.indexLabel.Text = "Index: ";
+            // 
+            // index
+            // 
+            this.index.Location = new System.Drawing.Point(396, 28);
+            this.index.Maximum = new decimal(new int[] {
+            63,
+            0,
+            0,
+            0});
+            this.index.Name = "index";
+            this.index.Size = new System.Drawing.Size(120, 31);
+            this.index.TabIndex = 7;
+            this.index.ValueChanged += new System.EventHandler(this.index_ValueChanged);
+            // 
+            // okButton
+            // 
+            this.okButton.AutoSize = true;
+            this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.okButton.Location = new System.Drawing.Point(203, 347);
+            this.okButton.Name = "okButton";
+            this.okButton.Size = new System.Drawing.Size(163, 35);
+            this.okButton.TabIndex = 20;
+            this.okButton.Text = "&OK";
+            this.okButton.UseVisualStyleBackColor = true;
+            // 
+            // cancelButton
+            // 
+            this.cancelButton.AutoSize = true;
+            this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.cancelButton.Location = new System.Drawing.Point(372, 347);
+            this.cancelButton.Name = "cancelButton";
+            this.cancelButton.Size = new System.Drawing.Size(163, 35);
+            this.cancelButton.TabIndex = 21;
+            this.cancelButton.Text = "&Cancel";
+            this.cancelButton.UseVisualStyleBackColor = true;
+			// 
+			// customColorBox
+			// 
+			this.customColorBox.BackColor = System.Drawing.Color.MediumTurquoise;
+            this.customColorBox.Location = new System.Drawing.Point(29, 277);
+            this.customColorBox.Name = "customColorBox";
+            this.customColorBox.Size = new System.Drawing.Size(340, 35);
+            this.customColorBox.TabIndex = 10;
+            this.customColorBox.TabStop = false;
+            this.customColorBox.Click += new System.EventHandler(this.customColor_Click);
+            // 
+            // colorChange
+            // 
+            this.colorChange.AutoSize = true;
+            this.colorChange.Location = new System.Drawing.Point(388, 273);
+            this.colorChange.Name = "colorChange";
+            this.colorChange.Size = new System.Drawing.Size(147, 35);
+            this.colorChange.TabIndex = 11;
+            this.colorChange.Text = "&Change...";
+            this.colorChange.UseVisualStyleBackColor = true;
+            this.colorChange.Click += new System.EventHandler(this.customColor_Click);
+            // 
+            // label1
+            // 
+            this.label1.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+            this.label1.Location = new System.Drawing.Point(33, 228);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(500, 2);
+            this.label1.TabIndex = 12;
+			// 
+			// customColorOverlay
+			// 
+			this.customColorOverlay.BackColor = System.Drawing.Color.Gray;
+            this.customColorOverlay.Location = new System.Drawing.Point(29, 277);
+            this.customColorOverlay.Name = "customColorOverlay";
+            this.customColorOverlay.Size = new System.Drawing.Size(340, 35);
+            this.customColorOverlay.TabIndex = 13;
+            this.customColorOverlay.TabStop = false;
+            this.customColorOverlay.Visible = false;
+            // 
+            // BackgroundColorDialog
+            // 
+            this.AcceptButton = this.okButton;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cancelButton;
+            this.ClientSize = new System.Drawing.Size(566, 399);
+            this.Controls.Add(this.customColorOverlay);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.colorChange);
+            this.Controls.Add(this.customColorBox);
+            this.Controls.Add(this.cancelButton);
+            this.Controls.Add(this.okButton);
+            this.Controls.Add(this.index);
+            this.Controls.Add(this.indexLabel);
+            this.Controls.Add(this.palettePanel);
+            this.Controls.Add(this.useCustomColor);
+            this.Controls.Add(this.useLevelColor);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "BackgroundColorDialog";
+            this.ShowIcon = false;
+            this.ShowInTaskbar = false;
+            this.Text = "Background Color...";
+            ((System.ComponentModel.ISupportInitialize)(this.index)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.customColorBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.customColorOverlay)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+		}
+
+		#endregion
+
+		internal System.Windows.Forms.RadioButton useLevelColor;
+		internal System.Windows.Forms.RadioButton useCustomColor;
+		private System.Windows.Forms.Panel palettePanel;
+		private System.Windows.Forms.Label indexLabel;
+		private System.Windows.Forms.Button okButton;
+		private System.Windows.Forms.Button cancelButton;
+		internal System.Windows.Forms.NumericUpDown index;
+		internal System.Windows.Forms.PictureBox customColorBox;
+		private System.Windows.Forms.Button colorChange;
+		private System.Windows.Forms.Label label1;
+		internal System.Windows.Forms.PictureBox customColorOverlay;
+	}
+}

--- a/SonLVL/BackgroundColorDialog.cs
+++ b/SonLVL/BackgroundColorDialog.cs
@@ -1,0 +1,99 @@
+﻿using SonicRetro.SonLVL.API;
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace SonicRetro.SonLVL
+{
+	public partial class BackgroundColorDialog : Form
+	{
+		Graphics PalettePanelGfx;
+		Bitmap palette;
+		Point selection;
+
+		public BackgroundColorDialog()
+		{
+			InitializeComponent();
+
+			PalettePanelGfx = palettePanel.CreateGraphics();
+			PalettePanelGfx.SetOptions();
+
+			BitmapBits bitmap = new BitmapBits(512, 128);
+			if (LevelData.Palette == null)
+			{
+				palette = bitmap.ToBitmap(new Color[] { Color.Black });
+			}
+			else
+			{
+				Color[] pal = new Color[64];
+
+				for (int y = 0; y < 4; y++)
+					for (int x = 0; x < 16; x++)
+					{
+						byte index = (byte)((y * 16) + x);
+						pal[index] = LevelData.Palette[LevelData.CurPal][y, x].RGBColor;
+						bitmap.FillRectangle(index, x * 32, y * 32, 32, 32);
+					}
+
+				palette = bitmap.ToBitmap(pal);
+			}
+		}
+
+		Brush brush = new SolidBrush(Color.FromArgb(120, Color.Gray));
+		private void DrawPalette()
+		{
+			PalettePanelGfx.DrawImage(palette, 0, 0, 256, 64);
+			PalettePanelGfx.DrawRectangle(Pens.Yellow, selection.X * 16, selection.Y * 16, 15, 15);
+			if (!useLevelColor.Checked)
+				PalettePanelGfx.FillRectangle(brush, 0, 0, 256, 123);
+		}
+		
+		private void palettePanel_MouseDown(object sender, MouseEventArgs e)
+		{
+			if (!useLevelColor.Checked) return;
+
+			selection = e.Location;
+			selection.X /= 16; selection.Y = Math.Min(selection.Y / 16, 15);
+			index.Value = selection.X + (selection.Y * 16);
+			DrawPalette();
+		}
+
+		private void palettePanel_Paint(object sender, PaintEventArgs e)
+		{
+			DrawPalette();
+		}
+	
+		private void useLevelColor_CheckedChanged(object sender, EventArgs e)
+		{
+			index.Enabled = useLevelColor.Checked;
+			DrawPalette();
+		}
+
+		private void index_ValueChanged(object sender, EventArgs e)
+		{
+			selection.X = (int)index.Value & 15;
+			selection.Y = (int)index.Value / 16;
+			DrawPalette();
+		}
+
+		private void customColor_Click(object sender, EventArgs e)
+		{
+			ColorDialog a = new ColorDialog
+			{
+				AllowFullOpen = true,
+				AnyColor = true,
+				FullOpen = true,
+				SolidColorOnly = true,
+				Color = customColorBox.BackColor
+			};
+			if (a.ShowDialog() == DialogResult.OK)
+				customColorBox.BackColor = a.Color;
+		}
+
+		private void useCustomColor_CheckedChanged(object sender, EventArgs e)
+		{
+			colorChange.Enabled = useCustomColor.Checked;
+			customColorOverlay.Visible = !useCustomColor.Checked;
+		}
+	}
+}

--- a/SonLVL/BackgroundColorDialog.resx
+++ b/SonLVL/BackgroundColorDialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/SonLVL/MainForm.Designer.cs
+++ b/SonLVL/MainForm.Designer.cs
@@ -151,6 +151,7 @@ namespace SonicRetro.SonLVL.GUI
             this.hideDebugObjectsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.objectsAboveHighPlaneToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.hUDToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.backgroundColorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.invertColorsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.waterPaletteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.selectPaletteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -1647,6 +1648,7 @@ namespace SonicRetro.SonLVL.GUI
             this.hideDebugObjectsToolStripMenuItem,
             this.objectsAboveHighPlaneToolStripMenuItem,
             this.hUDToolStripMenuItem,
+            this.backgroundColorToolStripMenuItem,
             this.invertColorsToolStripMenuItem,
             this.waterPaletteToolStripMenuItem,
             this.layersToolStripMenuItem,
@@ -1697,6 +1699,13 @@ namespace SonicRetro.SonLVL.GUI
             this.hUDToolStripMenuItem.ShortcutKeyDisplayString = "O";
             this.hUDToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
             this.hUDToolStripMenuItem.Text = "&HUD";
+            // 
+            // backgroundColorToolStripMenuItem
+            // 
+            this.backgroundColorToolStripMenuItem.Name = "backgroundColorToolStripMenuItem";
+            this.backgroundColorToolStripMenuItem.Size = new System.Drawing.Size(221, 22);
+            this.backgroundColorToolStripMenuItem.Text = "&Background Color...";
+            this.backgroundColorToolStripMenuItem.Click += new System.EventHandler(this.backgroundColorToolStripMenuItem_Click);
             // 
             // invertColorsToolStripMenuItem
             // 
@@ -3857,6 +3866,7 @@ namespace SonicRetro.SonLVL.GUI
 		private System.Windows.Forms.ToolStripMenuItem flipChunkBlocksHorizontallyToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem flipChunkBlocksVerticallyToolStripMenuItem;
 		private System.Windows.Forms.ToolStripButton enableDraggingPaletteButton;
+		private System.Windows.Forms.ToolStripMenuItem backgroundColorToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem invertColorsToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem layoutSwapOptionToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem optionAToolStripMenuItem;

--- a/SonLVL/MainForm.cs
+++ b/SonLVL/MainForm.cs
@@ -47,16 +47,27 @@ namespace SonicRetro.SonLVL.GUI
 		void LevelData_PaletteChangedEvent()
 		{
 			LevelData.BmpPal.Entries.CopyTo(LevelImgPalette.Entries, 0);
-			LevelImgPalette.Entries[LevelData.ColorTransparent] = LevelData.PaletteToColor(2, 0, false);
+			
+			if (Settings.BackgroundColor.A < 64)
+				LevelImgPalette.Entries[LevelData.ColorTransparent] = LevelData.PaletteToColor(Settings.BackgroundColor.A / 16, Settings.BackgroundColor.A & 15, false);
+			else
+				LevelImgPalette.Entries[LevelData.ColorTransparent] = Settings.BackgroundColor;
+
 			if (LevelData.WaterPalette != -1)
 			{
-				LevelImgPalette.Entries[128] = LevelData.Palette[LevelData.WaterPalette][2, 0].RGBColor;
+				if (Settings.BackgroundColor.A < 64)
+					LevelImgPalette.Entries[LevelData.ColorTransparent | 0x80] = LevelData.Palette[LevelData.WaterPalette][Settings.BackgroundColor.A / 16, Settings.BackgroundColor.A & 15].RGBColor;
+				else
+					LevelImgPalette.Entries[LevelData.ColorTransparent | 0x80] = Settings.BackgroundColor;
+
 				for (int i = 129; i < 192; i++)
 					LevelImgPalette.Entries[i] = LevelData.Palette[LevelData.WaterPalette][(i - 128) / 16, i % 16].RGBColor;
 			}
+
 			if (invertColorsToolStripMenuItem.Checked)
 				for (int i = 0; i < 256; i++)
 					LevelImgPalette.Entries[i] = LevelImgPalette.Entries[i].Invert();
+			
 			LevelImgPalette.Entries[LevelData.ColorWhite] = Color.White;
 			LevelImgPalette.Entries[LevelData.ColorYellow] = Color.Yellow;
 			LevelImgPalette.Entries[LevelData.ColorBlack] = Color.Black;
@@ -589,7 +600,10 @@ namespace SonicRetro.SonLVL.GUI
 			}
 			LevelImgPalette = new Bitmap(1, 1, PixelFormat.Format8bppIndexed).Palette;
 			LevelData.BmpPal.Entries.CopyTo(LevelImgPalette.Entries, 0);
-			LevelImgPalette.Entries[LevelData.ColorTransparent] = LevelData.PaletteToColor(2, 0, false);
+			if (Settings.BackgroundColor.A < 64)
+				LevelImgPalette.Entries[LevelData.ColorTransparent] = LevelData.PaletteToColor(Settings.BackgroundColor.A / 16, Settings.BackgroundColor.A & 15, false);
+			else
+				LevelImgPalette.Entries[LevelData.ColorTransparent] = Settings.BackgroundColor;
 			LevelImgPalette.Entries[LevelData.ColorWhite] = Color.White;
 			LevelImgPalette.Entries[LevelData.ColorYellow] = Color.Yellow;
 			LevelImgPalette.Entries[LevelData.ColorBlack] = Color.Black;
@@ -820,9 +834,14 @@ namespace SonicRetro.SonLVL.GUI
 				LevelData.WaterHeight = (ushort)LevelData.Level.WaterHeight;
 				if (LevelData.WaterPalette != -1)
 				{
-					LevelImgPalette.Entries[128] = LevelData.Palette[LevelData.WaterPalette][2, 0].RGBColor;
+					if (Settings.BackgroundColor.A < 64)
+						LevelImgPalette.Entries[LevelData.ColorTransparent | 0x80] = LevelData.Palette[LevelData.WaterPalette][Settings.BackgroundColor.A / 16, Settings.BackgroundColor.A & 15].RGBColor;
+					else
+						LevelImgPalette.Entries[LevelData.ColorTransparent | 0x80] = Settings.BackgroundColor;
+
 					for (int i = 129; i < 192; i++)
 						LevelImgPalette.Entries[i] = LevelData.Palette[LevelData.WaterPalette][(i - 128) / 16, i % 16].RGBColor;
+					
 					LevelImgPalette.Entries[LevelData.ColorWhite | 0x80] = Color.White;
 					LevelImgPalette.Entries[LevelData.ColorYellow | 0x80] = Color.Yellow;
 					LevelImgPalette.Entries[LevelData.ColorBlack | 0x80] = Color.Black;
@@ -1158,6 +1177,54 @@ namespace SonicRetro.SonLVL.GUI
 		{
 			objectsAboveHighPlaneToolStripMenuItem.Checked = !objectsAboveHighPlaneToolStripMenuItem.Checked;
 			DrawLevel();
+		}
+
+		private void backgroundColorToolStripMenuItem_Click(object sender, EventArgs e)
+		{
+			using (BackgroundColorDialog dialog = new BackgroundColorDialog())
+			{
+				if (Settings.BackgroundColor.A < 64)
+				{
+					dialog.index.Value = Settings.BackgroundColor.A;
+					dialog.customColorOverlay.Visible = dialog.useLevelColor.Checked = true;
+				}
+				else
+				{
+					dialog.index.Value = 32;
+					dialog.index.Enabled = false;
+					dialog.useCustomColor.Checked = true;
+				}
+
+				dialog.customColorBox.BackColor = Color.FromArgb(255, Settings.BackgroundColor);
+
+				if (dialog.ShowDialog(this) == DialogResult.OK)
+				{
+					if (dialog.useLevelColor.Checked)
+						Settings.BackgroundColor = Color.FromArgb((int)dialog.index.Value, Settings.BackgroundColor);
+					else
+						Settings.BackgroundColor = dialog.customColorBox.BackColor;
+
+					if (loaded)
+					{
+						if (Settings.BackgroundColor.A < 64)
+							LevelImgPalette.Entries[LevelData.ColorTransparent] = LevelData.PaletteToColor(Settings.BackgroundColor.A / 16, Settings.BackgroundColor.A & 15, false);
+						else
+							LevelImgPalette.Entries[LevelData.ColorTransparent] = Settings.BackgroundColor;
+
+						if (LevelData.WaterPalette != -1)
+						{
+							if (Settings.BackgroundColor.A < 64)
+								LevelImgPalette.Entries[LevelData.ColorTransparent | 0x80] = LevelData.Palette[LevelData.WaterPalette][Settings.BackgroundColor.A / 16, Settings.BackgroundColor.A & 15].RGBColor;
+							else
+								LevelImgPalette.Entries[LevelData.ColorTransparent | 0x80] = Settings.BackgroundColor;
+						}
+
+						DrawBlockPicture();
+						DrawChunkPicture();
+						DrawLevel();
+					}
+				}
+			}
 		}
 
 		private void invertColorsToolStripMenuItem_Click(object sender, EventArgs e)

--- a/SonLVL/Settings.cs
+++ b/SonLVL/Settings.cs
@@ -36,6 +36,11 @@ namespace SonicRetro.SonLVL
 		[IniIgnore]
 		public byte ObjectGridSize { get; set; }
 		public string Username { get; set; }
+
+		// If alpha is >63, then R/G/B are the background colour to be used in the editor
+		// Otherwise, if alpha < 255, then it's a palette index (from 0-63) to use as the background colour instead (while the previous custom colour is still preserved in R/G/B)
+		public Color BackgroundColor { get; set; }
+		
 		public bool IncludeObjectsInForegroundSelection { get; set; }
 		[DefaultValue(true)]
 		public bool TransparentBackgroundExport { get; set; }
@@ -93,6 +98,7 @@ namespace SonicRetro.SonLVL
 				result.ShowGrid = oldset.ShowGrid;
 				result.GridColor = oldset.GridColor;
 				result.Username = oldset.Username;
+				result.BackgroundColor = Color.FromArgb(32, 30, 80, 100);
 				result.IncludeObjectsInForegroundSelection = oldset.IncludeObjectsInForegroundSelection;
 				result.TransparentBackgroundExport = true;
 				result.ViewLowPlane = result.ViewHighPlane = true;

--- a/SonLVL/SonLVL.GUI.csproj
+++ b/SonLVL/SonLVL.GUI.csproj
@@ -49,6 +49,12 @@
       <DependentUpon>AddGroupDialog.cs</DependentUpon>
     </Compile>
     <Compile Include="AnimationInfo.cs" />
+    <Compile Include="BackgroundColorDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="BackgroundColorDialog.Designer.cs">
+      <DependentUpon>BackgroundColorDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="ChunkBlockEditor.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -219,6 +225,9 @@
     </Compile>
     <EmbeddedResource Include="AddGroupDialog.resx">
       <DependentUpon>AddGroupDialog.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="BackgroundColorDialog.resx">
+      <DependentUpon>BackgroundColorDialog.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="ChunkBlockEditor.resx">
       <DependentUpon>ChunkBlockEditor.cs</DependentUpon>


### PR DESCRIPTION
This PR adds a new background colour setting to SonLVL, located under the View menu:
<img width="50%" src="https://github.com/user-attachments/assets/22fac9ba-ec07-4c3a-9c68-b202ae6cdc39" />

This setting allows the user to customise the background colour of the level in the editor, without actually changing the palette data associated with the stage itself. Pressing the "Background Color..." button brings up the following form:
<img width="50%" src="https://github.com/user-attachments/assets/3143d34d-5b35-4c8b-b2c0-70f4a48ab13b" />

From here, the user has two choices. They can either:
- Use a fixed level palette index for the background. They can choose from any index between 0 and 63, with the value defaulting to 32, or the first colour of the third palette row. 
- Or, they can use a constant colour for the background instead, completely detached from the level's colour palette. This will stay the same across all stages opened in the editor.

This helps cases where the background colour could make elements in the actual level view blend in. For example, many stages across the classic Sonic games would have a background colour of black when opened in SonLVL. However, given that the collision view also uses black, this made the collision view much harder to use in those stages. However, with the ability to set a constant background colour that doesn't depend on the level palette, it is now much easier to view the collision of levels:
<img width="75%" src="https://github.com/user-attachments/assets/c9096af1-1df2-492e-b8f3-83c5aaeddcb7" />
