### PR TITLE
Fix S1SSEdit startup crash with grid enabled

### DIFF
--- a/S1SSEdit/MainForm.cs
+++ b/S1SSEdit/MainForm.cs
@@ -94,12 +94,12 @@ namespace S1SSEdit
 				settings.RecentFiles = mru;
 				recentFilesToolStripMenuItem.Enabled = mru.Count > 0;
 			}
+			layoutgfx = layoutPanel.CreateGraphics();
+			layoutgfx.SetOptions();
 			saveUndoHistoryToolStripMenuItem.Checked = settings.SaveUndoHistory;
 			autoincrementAnimatedBlocksToolStripMenuItem.Checked = settings.AutoIncrementAnimatedBlocks;
 			showNumbersOnWallsToolStripMenuItem.Checked = settings.ShowNumbersOnWalls;
 			showGridToolStripMenuItem.Checked = settings.ShowGrid;
-			layoutgfx = layoutPanel.CreateGraphics();
-			layoutgfx.SetOptions();
 		}
 
 		private static T DeserializeCompressed<T>(string fn)


### PR DESCRIPTION
Fixes an issue where, if the `ShowGrid` option was enabled in the user's settings file, S1SSEdit would crash on startup every time the program was opened. This was because setting `showGridToolStripMenuItem.Checked` to true would attempt to redraw the level, but because `layoutgfx` hasn't been initialised yet, a crash would occur.

Fixes #225.